### PR TITLE
feat: Enhance promotion action with run number tracking and improved PR titles

### DIFF
--- a/.github/actions/promote-branch/action.yml
+++ b/.github/actions/promote-branch/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Version being promoted (e.g., v1.2.3, auto-detected from git tags if not provided)'
     required: false
     default: ''
+  run_number:
+    description: 'GitHub Actions run number for tracking promotion lineage'
+    required: false
+    default: ''
   configPath:
     description: 'Path to .pipecraftrc.json config file'
     required: false
@@ -202,8 +206,14 @@ runs:
         SOURCE="${{ inputs.sourceBranch }}"
         VERSION="${{ steps.get-version.outputs.version }}"
         AUTO_MERGE="${{ steps.read-config.outputs.autoMerge }}"
+        RUN_NUMBER="${{ inputs.run_number }}"
 
-        TITLE="🚀 Release $VERSION to $TARGET"
+        # Build descriptive title with run number for traceability
+        if [ -n "$RUN_NUMBER" ]; then
+          TITLE="🚀 Release $VERSION to $TARGET (run #$RUN_NUMBER from $SOURCE)"
+        else
+          TITLE="🚀 Release $VERSION to $TARGET (from $SOURCE)"
+        fi
 
         # Determine merge behavior text
         if [ "$AUTO_MERGE" == "true" ]; then


### PR DESCRIPTION
### Summary

**Type:** feat

* **What kind of change does this PR introduce?**
  * This PR introduces enhancements to the GitHub Actions used for promoting branches by adding run number tracking and improving the PR titles for better traceability and context.

* **What is the current behavior?**
  * Currently, the promotion action does not track the run number, and the PR titles are generic without specific details about the source branch or the run number.

* **What is the new behavior?**
  * With this change, the run number is included as an optional input in the promotion action. PR titles are now dynamically generated to include the version being promoted, the target branch, the run number, and the source branch. This provides better visibility and traceability of promotion actions.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. Users can optionally include the run number for enhanced tracking, but the action remains backward compatible.

* **Has Testing been included for this PR?
  * Testing details are not provided in the diff. It is recommended to ensure that the new title generation and run number tracking are tested in the CI environment to verify their functionality.

### Other Information

This enhancement helps in debugging and tracking the promotion processes more effectively, especially in environments where multiple promotions may occur simultaneously. It also resolves issues with branch protection conflicts by ensuring that PR titles now contain all necessary context for auto-merging when enabled.

----