### PR TITLE
fix(templates): correct regex pattern in calculate-version template

### DIFF
--- a/src/templates/actions/calculate-version.yml.tpl.ts
+++ b/src/templates/actions/calculate-version.yml.tpl.ts
@@ -96,7 +96,7 @@ runs:
         echo "Current commit hash: $COMMIT_HASH"
         
         # Check for tags on the current commit
-        TAG=$(git tag --points-at $COMMIT_HASH | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+\\$' || true)
+        TAG=$(git tag --points-at $COMMIT_HASH | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+$' || true)
         echo "Tags found: $TAG"
         
         if [ -z "$TAG" ]; then


### PR DESCRIPTION
## Summary
Fix the regex pattern bug in the calculate-version template source to prevent the issue from reappearing in future generated actions.

## Context
This follows up on PR #100 which fixed the bug in the generated action file ([.github/actions/calculate-version/action.yml](/.github/actions/calculate-version/action.yml#L46)). However, the bug also existed in the source template, which would cause it to regenerate with the same bug.

## Problem in Template
The template at [src/templates/actions/calculate-version.yml.tpl.ts](src/templates/actions/calculate-version.yml.tpl.ts#L99) had:
```typescript
TAG=$(git tag --points-at $COMMIT_HASH | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+\\$' || true)
```

The `\\$` escapes to `\$` in the generated YAML, which looks for a literal dollar sign instead of end-of-line.

## Solution
Changed to:
```typescript
TAG=$(git tag --points-at $COMMIT_HASH | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+$' || true)
```

Now the `$` properly serves as the end-of-line anchor in the regex.

## Impact
- Future `pipecraft generate` commands will create actions with the correct regex
- Prevents the version detection bug from recurring
- Maintains consistency between template source and generated actions

## Related
- Fixes the root cause identified in #100
- Complements the direct fix to the generated action file

🤖 Generated with [Claude Code](https://claude.com/claude-code)