### PR TITLE
fix: correct publish workflow detection in create-release action

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'GitHub token for authentication'
     required: false
     default: ${{ github.token }}
+  publish-workflow:
+    description: 'Name of the publish workflow file to trigger (e.g., publish.yml)'
+    required: false
+    default: 'publish.yml'
 
 outputs:
   release_url:
@@ -79,20 +83,21 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
       run: |
         VERSION="${{ inputs.version }}"
+        PUBLISH_WORKFLOW="${{ inputs.publish-workflow }}"
 
-        # Check if publish.yml workflow exists
-        if gh workflow list | grep -q "publish.yml"; then
-          echo "🔄 Triggering publish workflow for $VERSION"
+        # Check if publish workflow file exists
+        if [ -f ".github/workflows/$PUBLISH_WORKFLOW" ]; then
+          echo "🔄 Triggering $PUBLISH_WORKFLOW for $VERSION"
 
           # Trigger the publish workflow with the release tag
           # This is necessary because GITHUB_TOKEN release creation doesn't trigger workflows
-          if gh workflow run publish.yml --field tag="$VERSION" 2>&1; then
+          if gh workflow run "$PUBLISH_WORKFLOW" --field tag="$VERSION" 2>&1; then
             echo "✅ Publish workflow triggered for $VERSION"
           else
             echo "⚠️  Failed to trigger publish workflow, but continuing"
-            echo "   Check that publish.yml accepts workflow_dispatch with a 'tag' input"
+            echo "   Check that $PUBLISH_WORKFLOW accepts workflow_dispatch with a 'tag' input"
           fi
         else
-          echo "ℹ️  No publish.yml workflow found - skipping publish trigger"
+          echo "ℹ️  No $PUBLISH_WORKFLOW workflow found - skipping publish trigger"
           echo "   This is normal if you don't have a separate publish workflow"
         fi

--- a/src/templates/actions/create-release.yml.tpl.ts
+++ b/src/templates/actions/create-release.yml.tpl.ts
@@ -32,6 +32,10 @@ const releaseActionTemplate = (ctx: any) => {
         description: 'GitHub token for authentication'
         required: false
         default: \${{ github.token }}
+      publish-workflow:
+        description: 'Name of the publish workflow file to trigger (e.g., publish.yml)'
+        required: false
+        default: 'publish.yml'
 
     outputs:
       release_url:
@@ -101,21 +105,22 @@ const releaseActionTemplate = (ctx: any) => {
             GH_TOKEN: \${{ inputs.token }}
           run: |
             VERSION="\${{ inputs.version }}"
+            PUBLISH_WORKFLOW="\${{ inputs.publish-workflow }}"
 
-            # Check if publish.yml workflow exists
-            if gh workflow list | grep -q "publish.yml"; then
-              echo "🔄 Triggering publish workflow for $VERSION"
+            # Check if publish workflow file exists
+            if [ -f ".github/workflows/$PUBLISH_WORKFLOW" ]; then
+              echo "🔄 Triggering $PUBLISH_WORKFLOW for $VERSION"
 
               # Trigger the publish workflow with the release tag
               # This is necessary because GITHUB_TOKEN release creation doesn't trigger workflows
-              if gh workflow run publish.yml --field tag="$VERSION" 2>&1; then
+              if gh workflow run "$PUBLISH_WORKFLOW" --field tag="$VERSION" 2>&1; then
                 echo "✅ Publish workflow triggered for $VERSION"
               else
                 echo "⚠️  Failed to trigger publish workflow, but continuing"
-                echo "   Check that publish.yml accepts workflow_dispatch with a 'tag' input"
+                echo "   Check that $PUBLISH_WORKFLOW accepts workflow_dispatch with a 'tag' input"
               fi
             else
-              echo "ℹ️  No publish.yml workflow found - skipping publish trigger"
+              echo "ℹ️  No $PUBLISH_WORKFLOW workflow found - skipping publish trigger"
               echo "   This is normal if you don't have a separate publish workflow"
             fi`
 };


### PR DESCRIPTION
## Summary

The promote step was failing to detect the `publish.yml` workflow because it was checking workflow names via `gh workflow list` instead of checking if the workflow file exists. This caused the publish workflow to never be triggered after releases were created.

## Changes

- Add configurable `publish-workflow` input parameter (defaults to `publish.yml`)
- Replace workflow name check with file existence check using `[ -f ".github/workflows/$PUBLISH_WORKFLOW" ]`
- Update both the action and template files for consistency

## Why This Fix Works

The previous code used `gh workflow list | grep -q "publish.yml"` which searches for the string "publish.yml" in the workflow **names** (like "Publish to npm"), not filenames. Since our workflow is named "Publish to npm", the grep would never match "publish.yml" and would always report the workflow as not found.

The new code directly checks if the file exists: `[ -f ".github/workflows/$PUBLISH_WORKFLOW" ]`, which is more reliable and straightforward.

## Test Plan

- [x] Verify changes compile
- [ ] Wait for CI tests to pass
- [ ] Merge to develop
- [ ] Test on next release promotion to main

## Related Issues

Fixes the issue where v0.23.0 release on main did not trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)