### PR TITLE
fix: enable npm OIDC publishing with provenance attestation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,24 +41,15 @@ jobs:
       - name: Build package
         run: pnpm run build
 
-      - name: Upgrade npm
+      - name: Upgrade npm to latest (required for OIDC)
         run: npm install -g npm@latest
-
-      - name: Check npm version
-        run: npm --version
 
       - name: Set package version
         run: |
           TAG=${{ github.event.release.tag_name || inputs.tag }}
           VERSION=${TAG#v}
-          echo "=== Before npm pkg set ==="
-          echo "Repository field:"
-          cat package.json | jq '.repository'
           echo "Setting package version to $VERSION"
           npm pkg set version=$VERSION
-          echo "=== After npm pkg set ==="
-          echo "Repository field:"
-          cat package.json | jq '.repository'
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Changes

This PR enables npm OIDC publishing with provenance attestation, allowing the package to be published to npm directly from GitHub Actions without storing npm tokens.

### Key Changes

- **Upgraded npm to latest** (11.5.1+ required for OIDC support)
- **Updated Node.js to v24** for latest features and compatibility
- **Updated pnpm to latest** version
- **Configured OIDC authentication** via actions/setup-node with registry-url
- **Enabled provenance attestation** with --provenance flag

### Benefits

- **No npm tokens needed** - Uses GitHub's OIDC provider for authentication
- **Provenance attestation** - Cryptographic proof of package origin and build environment
- **Improved security** - No long-lived credentials stored in secrets
- **Transparency** - Provenance published to Sigstore transparency log

### Testing

Successfully tested with pipecraft@0.25.0 publication:
- Provenance statement: https://search.sigstore.dev/?logIndex=629043176
- Package published: https://www.npmjs.com/package/pipecraft/v/0.25.0

Resolves the issue where the publish workflow was failing with 404/ENEEDAUTH errors due to outdated npm version and missing OIDC configuration.