### PR TITLE
test: trigger docs deployment

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,6 +6,8 @@ const config: Config = {
   title: 'PipeCraft',
   tagline: 'Automated CI/CD Pipeline Generator for Trunk-Based Development',
   favicon: 'img/favicon.ico',
+  
+  // Test deployment trigger - small change to docs
 
   future: {
     v4: true,


### PR DESCRIPTION
Small change to test docs deployment workflow. This should trigger the deploy-docs job when merged to develop.