### PR TITLE
fix: correct broken trunk-flow documentation links

### DIFF
--- a/docs/docs/docs-index.md
+++ b/docs/docs/docs-index.md
@@ -12,7 +12,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 ### For New Users
 1. **[Main README](https://github.com/jamesvillarrubia/pipecraft#readme)** - Start here! Installation, quick start, and basic usage
-2. **[Current Trunk Flow](./trunk-flow.md)** - Understand how the trunk-based workflow works
+2. **[Current Trunk Flow](./flows/trunk-flow)** - Understand how the trunk-based workflow works
 3. **[Examples](https://github.com/jamesvillarrubia/pipecraft/tree/main/examples)** - Example configurations for different use cases
    - `basic-config.json` - Simple single-repo configuration
    - `monorepo-config.json` - Multi-domain monorepo configuration
@@ -29,7 +29,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 ## 📖 User Documentation
 
 ### Core Concepts
-- **[Current Trunk Flow](./trunk-flow.md)** - The ONE currently implemented workflow pattern
+- **[Current Trunk Flow](./flows/trunk-flow)** - The ONE currently implemented workflow pattern
   - How promotions work (develop → staging → main)
   - Auto-merge configuration
   - Domain-based testing
@@ -118,7 +118,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 | Document | Purpose | Audience |
 |----------|---------|----------|
 | [Main README](https://github.com/jamesvillarrubia/pipecraft#readme) | Installation, quick start, usage | All users |
-| [Current Trunk Flow](./trunk-flow.md) | Current implementation details | Users, contributors |
+| [Current Trunk Flow](./flows/trunk-flow) | Current implementation details | Users, contributors |
 | [Error Handling](./error-handling.md) | Troubleshooting guide | Users |
 | [Examples](https://github.com/jamesvillarrubia/pipecraft/tree/main/examples) | Configuration examples | Users |
 
@@ -144,7 +144,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 **Use PipeCraft**
 → Start with [Main README](https://github.com/jamesvillarrubia/pipecraft#readme)
-→ Then read [Current Trunk Flow](./trunk-flow.md)
+→ Then read [Current Trunk Flow](./flows/trunk-flow)
 → Check [Examples](https://github.com/jamesvillarrubia/pipecraft/tree/main/examples) for your use case
 
 **Troubleshoot an error**
@@ -154,7 +154,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 **Understand how PipeCraft works**
 → Read [Architecture](./architecture.md)
-→ Read [Current Trunk Flow](./trunk-flow.md)
+→ Read [Current Trunk Flow](./flows/trunk-flow)
 → Study [AST Operations](https://github.com/jamesvillarrubia/pipecraft/blob/main/docs/AST_OPERATIONS.md) for template internals
 
 **Contribute code**

--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -751,7 +751,7 @@ If you encounter an error not covered in this guide:
 ## Related Documentation
 
 - [Architecture](./architecture) - System design and components
-- [Current Trunk Flow](./trunk-flow) - Implementation details
+- [Current Trunk Flow](./flows/trunk-flow) - Implementation details
 - [Getting Started](./intro) - User guide and examples
 - [Testing Guide](./testing-guide) - Testing guidelines
 

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -914,7 +914,7 @@ PipeCraft provides comprehensive documentation for different aspects of the proj
 ### Core Documentation
 
 - **[Architecture](./architecture)** - System architecture overview, design patterns, and component interactions
-- **[Current Trunk Flow](./trunk-flow)** - Current implemented trunk-based development workflow
+- **[Current Trunk Flow](./flows/trunk-flow)** - Current implemented trunk-based development workflow
 - **[Error Handling](./error-handling)** - Error handling strategies and common error scenarios
 - **[Testing Guide](./testing-guide)** - Complete testing guide with examples and best practices
 
@@ -949,7 +949,7 @@ This release focuses on a **solid, working trunk-based development workflow** fo
 ✅ **Pre-flight checks** for smooth setup  
 ✅ **Comprehensive documentation** and testing  
 
-See [Current Trunk Flow](./trunk-flow) for details on what's implemented.
+See [Current Trunk Flow](./flows/trunk-flow) for details on what's implemented.
 
 ### Planned Features
 


### PR DESCRIPTION
## Summary
Fixed broken links to trunk-flow documentation that were causing docs build failures in GitHub Actions.

## Changes
- Updated `docs/docs/docs-index.md`: Fixed 5 broken links to trunk-flow
- Updated `docs/docs/readme.md`: Fixed 1 broken link
- Updated `docs/docs/error-handling.md`: Fixed 1 broken link

## Problem
The documentation referenced `./trunk-flow.md` but the actual file is located at `./flows/trunk-flow.md`, causing Docusaurus to fail during build with "broken links" errors.

## Solution
Updated all references to point to the correct path: `./flows/trunk-flow`

## Test Plan
- [x] Fixed all broken link references
- [x] Links now point to correct file location
- [ ] Verify docs build successfully in CI

## Related Issues
Resolves documentation build failures from deploy-docs workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)