### PR TITLE
docs: update README example to use YAML format

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,27 +136,37 @@ Then add npm scripts to your package.json:
 
 ## Simple Example
 
-Create a `.pipecraftrc.json` configuration describing your project:
+Create a `.pipecraftrc` configuration describing your project:
 
-```json
-{
-  "ciProvider": "github",
-  "mergeStrategy": "fast-forward",
-  "requireConventionalCommits": true,
-  "initialBranch": "develop",
-  "finalBranch": "main",
-  "branchFlow": ["develop", "staging", "main"],
-  "domains": {
-    "api": {
-      "paths": ["apps/api/**", "libs/api-core/**"],
-      "description": "API services and core logic"
-    },
-    "web": {
-      "paths": ["apps/web/**", "libs/ui-components/**"],
-      "description": "Web application and UI"
-    }
-  }
-}
+```yaml
+# PipeCraft Configuration
+ciProvider: github
+mergeStrategy: fast-forward
+requireConventionalCommits: true
+
+# Branch flow configuration
+initialBranch: develop
+finalBranch: main
+
+# Promotion flow: develop → staging → main
+branchFlow:
+  - develop
+  - staging
+  - main
+
+# Domain definitions - what parts of your codebase trigger which jobs
+domains:
+  api:
+    description: 'API services and core logic'
+    paths:
+      - apps/api/**
+      - libs/api-core/**
+
+  web:
+    description: 'Web application and UI'
+    paths:
+      - apps/web/**
+      - libs/ui-components/**
 ```
 
 Run `pipecraft generate` and you get workflow scaffolding with:


### PR DESCRIPTION
## Summary
Update the README configuration example to use YAML format (`.pipecraftrc`) instead of JSON (`.pipecraftrc.json`) to match what `npx pipecraft init` actually generates.

## Changes
- Changed example from [README.md:139-159](README.md#L139-L159) to use YAML syntax
- Updated file name reference from `.pipecraftrc.json` to `.pipecraftrc`
- Added helpful comments to match the actual generated output

## Why
The `init` command generates `.pipecraftrc` in YAML format (see [src/generators/init.tpl.ts:640-641](src/generators/init.tpl.ts#L640-L641)), but the README was showing a JSON example. This could confuse users who expect to see JSON after running the init command.

## Test plan
- [x] Changes committed
- [x] Formatting verified with Prettier
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)