### PR TITLE
fix: update action reference organization to the-craftlab

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -223,7 +223,7 @@ export interface PipecraftConfig {
    * How workflows should reference PipeCraft actions.
    *
    * - 'local': Actions copied to ./.github/actions/ (default, full control)
-   * - 'remote': Reference published marketplace actions (e.g., pipecraft-lab/pipecraft/actions/detect-changes@v1)
+   * - 'remote': Reference published marketplace actions (e.g., the-craftlab/pipecraft/actions/detect-changes@v1)
    * - 'source': Use ./actions/ from repo root (internal use only, for PipeCraft's own CI)
    *
    * @default 'local'
@@ -236,7 +236,7 @@ export interface PipecraftConfig {
    * // User repos (remote mode)
    * actionSourceMode: 'remote'
    * actionVersion: 'v1.2.3'
-   * // Generates: uses: pipecraft-lab/pipecraft/actions/detect-changes@v1.2.3
+   * // Generates: uses: the-craftlab/pipecraft/actions/detect-changes@v1.2.3
    *
    * // PipeCraft repo only (source mode)
    * actionSourceMode: 'source'

--- a/src/utils/action-reference.ts
+++ b/src/utils/action-reference.ts
@@ -27,7 +27,7 @@ import type { PipecraftConfig } from '../types/index.js'
  *   actionSourceMode: 'remote',
  *   actionVersion: 'v1.2.3'
  * })
- * // Returns: 'pipecraft-lab/pipecraft/actions/detect-changes@v1.2.3'
+ * // Returns: 'the-craftlab/pipecraft/actions/detect-changes@v1.2.3'
  *
  * // Repository mode (PipeCraft's own CI)
  * getActionReference('detect-changes', { actionSourceMode: 'source' })
@@ -45,7 +45,7 @@ export function getActionReference(actionName: string, config: Partial<Pipecraft
     case 'remote': {
       // Reference published marketplace actions
       const version = config.actionVersion || 'v1'
-      return `pipecraft-lab/pipecraft/actions/${actionName}@${version}`
+      return `the-craftlab/pipecraft/actions/${actionName}@${version}`
     }
 
     case 'source':


### PR DESCRIPTION
## Summary

Updates the action reference organization from `pipecraft-lab` to `the-craftlab` in source code documentation and implementation.

This is a follow-up to PR #252 that updates the remaining organization references in the codebase.

## Changes

### Source Code Updates
- ✅ Updated `src/types/index.ts` - Action reference examples in JSDoc comments
- ✅ Updated `src/utils/action-reference.ts` - Action reference implementation and JSDoc

### Impact

When users configure `actionSourceMode: 'remote'`, the generated workflows will correctly reference:
```
the-craftlab/pipecraft/actions/detect-changes@v1
```

Instead of the old:
```
pipecraft-lab/pipecraft/actions/detect-changes@v1
```

## Related

- Related to #252