### PR TITLE
fix: correct relative links in docs for Docusaurus

### DIFF
--- a/docs/docs/docs-index.md
+++ b/docs/docs/docs-index.md
@@ -13,7 +13,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 ### For New Users
 
 1. **[Main README](https://github.com/pipecraft-lab/pipecraft#readme)** - Start here! Installation, quick start, and basic usage
-2. **[Current Trunk Flow](./flows/trunk-flow)** - Understand how the trunk-based workflow works
+2. **[Current Trunk Flow](flows/trunk-flow)** - Understand how the trunk-based workflow works
 3. **[Examples](https://github.com/pipecraft-lab/pipecraft/tree/main/examples)** - Example configurations for different use cases
    - `basic-config.json` - Simple single-repo configuration
    - `monorepo-config.json` - Multi-domain monorepo configuration
@@ -24,7 +24,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 - 📦 [Installation](https://github.com/pipecraft-lab/pipecraft#installation)
 - ⚡ [Quick Start](https://github.com/pipecraft-lab/pipecraft#quick-start)
 - ⚙️ [Configuration Options](https://github.com/pipecraft-lab/pipecraft#configuration-options)
-- 🐛 [Troubleshooting](./error-handling.md)
+- 🐛 [Troubleshooting](error-handling.md)
 
 ---
 
@@ -32,14 +32,14 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 ### Core Concepts
 
-- **[Current Trunk Flow](./flows/trunk-flow)** - The ONE currently implemented workflow pattern
+- **[Current Trunk Flow](flows/trunk-flow)** - The ONE currently implemented workflow pattern
 
   - How promotions work (develop → staging → main)
   - Auto-merge configuration
   - Domain-based testing
   - Semantic versioning integration
 
-- **[Architecture](./architecture.md)** - System design and how PipeCraft works
+- **[Architecture](architecture.md)** - System design and how PipeCraft works
   - Component overview
   - Data flow diagrams
   - Design decisions explained
@@ -47,7 +47,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 ### Guides & References
 
-- **[Error Handling](./error-handling.md)** - Complete error types, causes, and solutions
+- **[Error Handling](error-handling.md)** - Complete error types, causes, and solutions
 
   - Configuration errors
   - Pre-flight check failures
@@ -74,7 +74,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 ### Development Guides
 
-- **[Architecture](./architecture.md)** - Required reading for contributors
+- **[Architecture](architecture.md)** - Required reading for contributors
 
   - System components in detail
   - How everything fits together
@@ -95,7 +95,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 ### Contributing Workflow
 
-1. Read [Architecture](./architecture.md) to understand the system
+1. Read [Architecture](architecture.md) to understand the system
 2. Read [Test Documentation](https://github.com/pipecraft-lab/pipecraft/blob/main/tests/README.md) to understand testing
 3. Pick an issue or feature to work on
 4. Write tests first (TDD approach)
@@ -132,15 +132,15 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 | Document                                                                  | Purpose                          | Audience            |
 | ------------------------------------------------------------------------- | -------------------------------- | ------------------- |
 | [Main README](https://github.com/pipecraft-lab/pipecraft#readme)          | Installation, quick start, usage | All users           |
-| [Current Trunk Flow](./flows/trunk-flow)                                  | Current implementation details   | Users, contributors |
-| [Error Handling](./error-handling.md)                                     | Troubleshooting guide            | Users               |
+| [Current Trunk Flow](flows/trunk-flow)                                  | Current implementation details   | Users, contributors |
+| [Error Handling](error-handling.md)                                     | Troubleshooting guide            | Users               |
 | [Examples](https://github.com/pipecraft-lab/pipecraft/tree/main/examples) | Configuration examples           | Users               |
 
 ### Technical Documentation (Contributor-Facing)
 
 | Document                                                                                                  | Purpose                     | Audience              |
 | --------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------- |
-| [Architecture](./architecture.md)                                                                         | System design               | Contributors          |
+| [Architecture](architecture.md)                                                                         | System design               | Contributors          |
 | [AST Operations](https://github.com/pipecraft-lab/pipecraft/blob/main/docs/AST_OPERATIONS.md)             | YAML manipulation internals | Advanced contributors |
 | [Test Documentation](https://github.com/pipecraft-lab/pipecraft/blob/main/tests/README.md)                | Testing guide               | Contributors          |
 | [Repository Cleanup Plan](https://github.com/pipecraft-lab/pipecraft/blob/main/docs/REPO_CLEANUP_PLAN.md) | Repo organization           | Contributors          |
@@ -160,21 +160,21 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 **Use PipeCraft**
 → Start with [Main README](https://github.com/pipecraft-lab/pipecraft#readme)
-→ Then read [Current Trunk Flow](./flows/trunk-flow)
+→ Then read [Current Trunk Flow](flows/trunk-flow)
 → Check [Examples](https://github.com/pipecraft-lab/pipecraft/tree/main/examples) for your use case
 
 **Troubleshoot an error**
-→ Read [Error Handling](./error-handling.md)
+→ Read [Error Handling](error-handling.md)
 → Search for your error message
 → Follow the recovery steps
 
 **Understand how PipeCraft works**
-→ Read [Architecture](./architecture.md)
-→ Read [Current Trunk Flow](./flows/trunk-flow)
+→ Read [Architecture](architecture.md)
+→ Read [Current Trunk Flow](flows/trunk-flow)
 → Study [AST Operations](https://github.com/pipecraft-lab/pipecraft/blob/main/docs/AST_OPERATIONS.md) for template internals
 
 **Contribute code**
-→ Read [Architecture](./architecture.md) first
+→ Read [Architecture](architecture.md) first
 → Read [Test Documentation](https://github.com/pipecraft-lab/pipecraft/blob/main/tests/README.md)
 → Check [Repository Cleanup Plan](https://github.com/pipecraft-lab/pipecraft/blob/main/docs/REPO_CLEANUP_PLAN.md) for structure
 → Write tests, then code
@@ -182,7 +182,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 **Add a new feature**
 → Check [Roadmap](https://github.com/pipecraft-lab/pipecraft/blob/main/TRUNK_FLOW_PLAN.md) for planned features
-→ Read [Architecture](./architecture.md) for extension points
+→ Read [Architecture](architecture.md) for extension points
 → Discuss in GitHub issues first
 → Follow contributor workflow above
 

--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -781,7 +781,7 @@ If you encounter an error not covered in this guide:
 
 ## Related Documentation
 
-- [Architecture](./architecture) - System design and components
-- [Current Trunk Flow](./flows/trunk-flow) - Implementation details
-- [Getting Started](./intro) - User guide and examples
-- [Testing Guide](./testing-guide) - Testing guidelines
+- [Architecture](architecture) - System design and components
+- [Current Trunk Flow](flows/trunk-flow) - Implementation details
+- [Getting Started](intro) - User guide and examples
+- [Testing Guide](testing-guide) - Testing guidelines

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -376,7 +376,7 @@ Fix reported issues and try generating again.
    ```
 4. **Check change detection output**: Look at the `changes` job output
 
-See the [Troubleshooting guide](./troubleshooting.md) for detailed debugging steps.
+See the [Troubleshooting guide](troubleshooting.md) for detailed debugging steps.
 
 ---
 
@@ -390,7 +390,7 @@ PipeCraft workflows require:
 - **pull-requests: write** - For branch promotion PRs
 - **actions: read** (optional) - For triggering subsequent workflows
 
-These are standard for CI/CD automation. Review the [Security guide](./security.md) for details.
+These are standard for CI/CD automation. Review the [Security guide](security.md) for details.
 
 ### Can I use GitHub self-hosted runners?
 
@@ -582,7 +582,7 @@ Your customizations will be preserved during regeneration.
 
 ### How can I contribute?
 
-We welcome contributions! See the [Contributing guide](./contributing.md) for:
+We welcome contributions! See the [Contributing guide](contributing.md) for:
 
 - Development setup
 - Code architecture

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -368,13 +368,13 @@ You now have a working CI/CD pipeline. From here you can:
 
 **Add more domains** by editing `.pipecraftrc.json` and running `pipecraft generate` again. The workflow will update to include the new domains.
 
-**Learn about the architecture** by reading the [Architecture](./architecture) page to understand how PipeCraft works under the hood.
+**Learn about the architecture** by reading the [Architecture](architecture) page to understand how PipeCraft works under the hood.
 
-**Explore workflow patterns** by checking out [Trunk Flow](./flows/trunk-flow) to understand how code flows through your branches.
+**Explore workflow patterns** by checking out [Trunk Flow](flows/trunk-flow) to understand how code flows through your branches.
 
 ## Getting help
 
-If something goes wrong, check the [Troubleshooting](./troubleshooting) page for common issues and solutions.
+If something goes wrong, check the [Troubleshooting](troubleshooting) page for common issues and solutions.
 
 For questions or discussions, visit [GitHub Discussions](https://github.com/pipecraft-lab/pipecraft/discussions).
 

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -965,10 +965,10 @@ PipeCraft provides comprehensive documentation for different aspects of the proj
 
 ### Core Documentation
 
-- **[Architecture](./architecture)** - System architecture overview, design patterns, and component interactions
-- **[Current Trunk Flow](./flows/trunk-flow)** - Current implemented trunk-based development workflow
-- **[Error Handling](./error-handling)** - Error handling strategies and common error scenarios
-- **[Testing Guide](./testing-guide)** - Complete testing guide with examples and best practices
+- **[Architecture](architecture)** - System architecture overview, design patterns, and component interactions
+- **[Current Trunk Flow](flows/trunk-flow)** - Current implemented trunk-based development workflow
+- **[Error Handling](error-handling)** - Error handling strategies and common error scenarios
+- **[Testing Guide](testing-guide)** - Complete testing guide with examples and best practices
 
 ### Development Documentation
 
@@ -1001,7 +1001,7 @@ This release focuses on a **solid, working trunk-based development workflow** fo
 ✅ **Pre-flight checks** for smooth setup  
 ✅ **Comprehensive documentation** and testing
 
-See [Current Trunk Flow](./flows/trunk-flow) for details on what's implemented.
+See [Current Trunk Flow](flows/trunk-flow) for details on what's implemented.
 
 ### Planned Features
 

--- a/docs/docs/testing-guide.md
+++ b/docs/docs/testing-guide.md
@@ -550,7 +550,7 @@ npm run test:coverage
 ## Resources
 
 - [Vitest Documentation](https://vitest.dev/)
-- [PipeCraft Architecture](./architecture)
+- [PipeCraft Architecture](architecture)
 - [Test Structure](https://github.com/pipecraft-lab/pipecraft/tree/main/tests)
 - [Contributing Guide](https://github.com/pipecraft-lab/pipecraft/blob/main/CONTRIBUTING.md)
 


### PR DESCRIPTION
## Summary

Fix broken links in docs that were causing the docs build to fail.

## Changes

Changed `./page` to `page` format for internal doc links. Docusaurus resolves relative links differently when on the docs index page (`/docs`), so we use doc IDs instead.

**Files fixed:**
- docs-index.md
- error-handling.md
- faq.md
- intro.md
- readme.md
- testing-guide.md

## Test plan

- [ ] Docs build should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)