### PR TITLE
fix: use absolute paths for docs links

### DIFF
--- a/docs/docs/docs-index.md
+++ b/docs/docs/docs-index.md
@@ -13,7 +13,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 ### For New Users
 
 1. **[Main README](https://github.com/pipecraft-lab/pipecraft#readme)** - Start here! Installation, quick start, and basic usage
-2. **[Current Trunk Flow](flows/trunk-flow)** - Understand how the trunk-based workflow works
+2. **[Current Trunk Flow](/docs/flows/trunk-flow)** - Understand how the trunk-based workflow works
 3. **[Examples](https://github.com/pipecraft-lab/pipecraft/tree/main/examples)** - Example configurations for different use cases
    - `basic-config.json` - Simple single-repo configuration
    - `monorepo-config.json` - Multi-domain monorepo configuration
@@ -32,7 +32,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 ### Core Concepts
 
-- **[Current Trunk Flow](flows/trunk-flow)** - The ONE currently implemented workflow pattern
+- **[Current Trunk Flow](/docs/flows/trunk-flow)** - The ONE currently implemented workflow pattern
 
   - How promotions work (develop → staging → main)
   - Auto-merge configuration
@@ -132,7 +132,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 | Document                                                                  | Purpose                          | Audience            |
 | ------------------------------------------------------------------------- | -------------------------------- | ------------------- |
 | [Main README](https://github.com/pipecraft-lab/pipecraft#readme)          | Installation, quick start, usage | All users           |
-| [Current Trunk Flow](flows/trunk-flow)                                  | Current implementation details   | Users, contributors |
+| [Current Trunk Flow](/docs/flows/trunk-flow)                                  | Current implementation details   | Users, contributors |
 | [Error Handling](error-handling.md)                                     | Troubleshooting guide            | Users               |
 | [Examples](https://github.com/pipecraft-lab/pipecraft/tree/main/examples) | Configuration examples           | Users               |
 
@@ -160,7 +160,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 **Use PipeCraft**
 → Start with [Main README](https://github.com/pipecraft-lab/pipecraft#readme)
-→ Then read [Current Trunk Flow](flows/trunk-flow)
+→ Then read [Current Trunk Flow](/docs/flows/trunk-flow)
 → Check [Examples](https://github.com/pipecraft-lab/pipecraft/tree/main/examples) for your use case
 
 **Troubleshoot an error**
@@ -170,7 +170,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 
 **Understand how PipeCraft works**
 → Read [Architecture](architecture.md)
-→ Read [Current Trunk Flow](flows/trunk-flow)
+→ Read [Current Trunk Flow](/docs/flows/trunk-flow)
 → Study [AST Operations](https://github.com/pipecraft-lab/pipecraft/blob/main/docs/AST_OPERATIONS.md) for template internals
 
 **Contribute code**

--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -781,7 +781,7 @@ If you encounter an error not covered in this guide:
 
 ## Related Documentation
 
-- [Architecture](architecture) - System design and components
-- [Current Trunk Flow](flows/trunk-flow) - Implementation details
+- [Architecture](/docs/architecture) - System design and components
+- [Current Trunk Flow](/docs/flows/trunk-flow) - Implementation details
 - [Getting Started](intro) - User guide and examples
-- [Testing Guide](testing-guide) - Testing guidelines
+- [Testing Guide](/docs/testing-guide) - Testing guidelines

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -368,13 +368,13 @@ You now have a working CI/CD pipeline. From here you can:
 
 **Add more domains** by editing `.pipecraftrc.json` and running `pipecraft generate` again. The workflow will update to include the new domains.
 
-**Learn about the architecture** by reading the [Architecture](architecture) page to understand how PipeCraft works under the hood.
+**Learn about the architecture** by reading the [Architecture](/docs/architecture) page to understand how PipeCraft works under the hood.
 
-**Explore workflow patterns** by checking out [Trunk Flow](flows/trunk-flow) to understand how code flows through your branches.
+**Explore workflow patterns** by checking out [Trunk Flow](/docs/flows/trunk-flow) to understand how code flows through your branches.
 
 ## Getting help
 
-If something goes wrong, check the [Troubleshooting](troubleshooting) page for common issues and solutions.
+If something goes wrong, check the [Troubleshooting](/docs/troubleshooting) page for common issues and solutions.
 
 For questions or discussions, visit [GitHub Discussions](https://github.com/pipecraft-lab/pipecraft/discussions).
 

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -965,10 +965,10 @@ PipeCraft provides comprehensive documentation for different aspects of the proj
 
 ### Core Documentation
 
-- **[Architecture](architecture)** - System architecture overview, design patterns, and component interactions
-- **[Current Trunk Flow](flows/trunk-flow)** - Current implemented trunk-based development workflow
-- **[Error Handling](error-handling)** - Error handling strategies and common error scenarios
-- **[Testing Guide](testing-guide)** - Complete testing guide with examples and best practices
+- **[Architecture](/docs/architecture)** - System architecture overview, design patterns, and component interactions
+- **[Current Trunk Flow](/docs/flows/trunk-flow)** - Current implemented trunk-based development workflow
+- **[Error Handling](/docs/error-handling)** - Error handling strategies and common error scenarios
+- **[Testing Guide](/docs/testing-guide)** - Complete testing guide with examples and best practices
 
 ### Development Documentation
 
@@ -1001,7 +1001,7 @@ This release focuses on a **solid, working trunk-based development workflow** fo
 ✅ **Pre-flight checks** for smooth setup  
 ✅ **Comprehensive documentation** and testing
 
-See [Current Trunk Flow](flows/trunk-flow) for details on what's implemented.
+See [Current Trunk Flow](/docs/flows/trunk-flow) for details on what's implemented.
 
 ### Planned Features
 

--- a/docs/docs/testing-guide.md
+++ b/docs/docs/testing-guide.md
@@ -550,7 +550,7 @@ npm run test:coverage
 ## Resources
 
 - [Vitest Documentation](https://vitest.dev/)
-- [PipeCraft Architecture](architecture)
+- [PipeCraft Architecture](/docs/architecture)
 - [Test Structure](https://github.com/pipecraft-lab/pipecraft/tree/main/tests)
 - [Contributing Guide](https://github.com/pipecraft-lab/pipecraft/blob/main/CONTRIBUTING.md)
 


### PR DESCRIPTION
## Summary

Fix broken links in docs by using absolute paths (`/docs/page`) instead of relative paths.

The docs index page at `/docs` doesn't resolve relative links correctly, so absolute paths are needed.

## Test plan

- [ ] Docs build should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)