### PR TITLE
fix(calculate-version): fall back to nearest reachable tag + promotion docs

### DIFF
--- a/actions/calculate-version/action.yml
+++ b/actions/calculate-version/action.yml
@@ -123,6 +123,25 @@ runs:
           echo "version=v$VERSION" >> $GITHUB_OUTPUT
         fi
 
+    - name: Get nearest reachable tag
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_new.outputs.version == ''
+      id: get_version_nearest
+      shell: bash
+      run: |
+        # Fallback: when a promotion PR is merged as a merge commit, the release
+        # tag is reachable from HEAD but not directly on it, so the lookups above
+        # miss it and release-it finds no new version. Use the nearest reachable
+        # tag so the release is cut for the promoted version instead of being
+        # silently skipped. No-op in normal flows: this only runs when nothing
+        # else resolved a version.
+        NEAREST=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)
+        if echo "$NEAREST" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "Using nearest reachable tag: $NEAREST"
+          echo "version=$NEAREST" >> $GITHUB_OUTPUT
+        else
+          echo "No reachable version tag found"
+        fi
+
     - name: Set version output
       id: set_version
       shell: bash
@@ -136,6 +155,9 @@ runs:
         elif [ -n "${{ steps.get_version_new.outputs.version }}" ]; then
           echo "Using calculated version: ${{ steps.get_version_new.outputs.version }}"
           echo "version=${{ steps.get_version_new.outputs.version }}" >> $GITHUB_OUTPUT
+        elif [ -n "${{ steps.get_version_nearest.outputs.version }}" ]; then
+          echo "Using nearest reachable tag version: ${{ steps.get_version_nearest.outputs.version }}"
+          echo "version=${{ steps.get_version_nearest.outputs.version }}" >> $GITHUB_OUTPUT
         else
           echo "No version determined"
           echo "version=" >> $GITHUB_OUTPUT

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -60,6 +60,33 @@ If you want a commit to promote, make sure it uses a commit message that trigger
 git commit -m "feat: enable promotion"
 ```
 
+## No GitHub Release was created after merging a promotion PR
+
+If a promotion PR merged successfully but no tag/release was cut on the final
+branch — with no error in the logs — the most common cause is the **merge
+method** used on the promotion PR.
+
+PipeCraft creates the version tag on the initial branch and gates the release
+job to the final branch. The release job only runs when a version can be
+resolved on the final branch's `HEAD`. If the promotion PR is merged as a
+**merge commit**, the version tag is not on the final branch's `HEAD`, so the
+version resolves empty and the release is skipped.
+
+When `autoMerge` is disabled for the final branch (human-gated production
+promotion), merge promotion PRs using **fast-forward** or **rebase**, not a
+merge commit:
+
+```bash
+# Fast-forward (preferred) or rebase keeps the tagged commit on HEAD
+gh pr merge <pr> --rebase   # or: --merge is what to AVOID here
+```
+
+Two safeguards back this up: PipeCraft emits a `pipecraft` warning on the final
+branch when no version resolves, and `calculate-version` falls back to the
+nearest reachable tag (`git describe`) so a merge-commit promotion still cuts
+the release in most cases. Merging fast-forward/rebase avoids the situation
+entirely.
+
 ## Promotion fails with "Resource not accessible by integration"
 
 If you see an error like:

--- a/docs/plans/version-promotion-threading.md
+++ b/docs/plans/version-promotion-threading.md
@@ -1,0 +1,104 @@
+# Thread the established version through promotion (FOLLOW-UP B2)
+
+**Branch:** fix/version-promotion-robustness
+**Created:** 2026-06-15
+**Status:** Design note — NOT implemented (deferred as too large/risky for an
+unattended sitting; see "Why deferred")
+
+## Problem
+
+Release/tag jobs gate on a non-empty version. `calculate-version` resolves the
+version by precedence:
+
+1. `inputs.version` (explicit)
+2. exact tag on `HEAD` (`git tag --points-at HEAD`)
+3. recompute via `release-it`
+4. empty
+
+In a flow where the tag is created on the initial branch and `release` is gated
+to the final branch, a **merge-commit** promotion leaves the version tag off the
+final branch's `HEAD`. Steps 2 and 3 then yield nothing and the version resolves
+empty, so `release` silently skips — no tag-on-HEAD, no GitHub Release.
+
+## Mitigations already shipped (lightweight guards)
+
+- **Patch 2** (`fix/version-final-branch-warning`): emits a `::warning::pipecraft`
+  on the final branch when the version resolves empty, making the silent skip
+  visible.
+- **FOLLOW-UP B1** (this branch, commit `fix(calculate-version): fall back to
+nearest reachable tag`): adds a last-resort `git describe --tags --abbrev=0`
+  step so a merge-commit promotion still cuts the release in most cases.
+
+These reduce the blast radius but still rely on tag reachability/heuristics.
+
+## Durable fix (B2)
+
+Pass the **established version** into the final-branch pipeline invocation as an
+explicit input, so release no longer depends on tag-on-HEAD.
+
+Key finding while scoping: the promote job **already triggers the final-branch
+pipeline via `workflow_dispatch`** (see `docs/docs/troubleshooting.md` —
+"Resource not accessible by integration"; requires `actions: write`). So the
+plumbing for passing a value already exists — this is a `workflow_dispatch`
+input, not a new `workflow_call` wiring.
+
+### Proposed design
+
+1. The promote branch name already encodes the version:
+   `release/<src>-to-<dst>-<version>` (e.g. `release/develop-to-main-1.4.0`).
+   Parse `<version>` from the ref.
+2. Add a `version` input to the pipeline's `on.workflow_dispatch.inputs`.
+3. When the promote job dispatches the final-branch pipeline, pass the parsed
+   version as that input.
+4. The `version` job forwards `inputs.version` into the `calculate-version`
+   action's `version` input (precedence step 1), making release independent of
+   merge method.
+5. Keep B1's `git describe` fallback for the push-triggered path (when the
+   pipeline runs on `push`, not via dispatch, there is no input to forward).
+
+### Files to touch (templates are the source of truth)
+
+- `src/templates/workflows/pipeline.yml.tpl.ts` — add `workflow_dispatch.inputs.version`;
+  forward it into the version job's `with.version`.
+- `src/templates/actions/promote-branch.yml.tpl.ts` (and/or the promote job in
+  the pipeline template) — parse version from the promote ref and include it in
+  the dispatch payload.
+- Regenerate all committed action/workflow copies (`actions/`, `.github/actions/`,
+  `examples/**`) — NOTE the regeneration tooling is currently broken (see below).
+- Update snapshots: `tests/snapshots/__snapshots__/workflow-snapshots.test.ts.snap`
+  across every snapshot config.
+- Tests: add a contract test asserting the dispatch input is parsed/forwarded.
+
+## Why deferred (overnight)
+
+- Multi-file template change that ripples into many generated copies and **every**
+  snapshot config — high chance of a large, hard-to-review diff if done unattended.
+- The behavior is release-critical and not behaviorally testable locally without
+  running real dispatch flows.
+- B1 + Patch 2 already mitigate the concrete failure, so the urgency is lower.
+
+## Pre-existing blocker discovered: action-copy drift + broken sync tooling
+
+While doing B1 I found the committed `.github/actions/calculate-version/action.yml`
+and the three `examples/**` copies are **stale** relative to the template (older
+generation: a separate "Install dependencies" step, `npx release-it` without
+`--package`, "Using old/new version" wording). Only `actions/` (source mode) was
+in sync. Also:
+
+- `package.json` `sync-actions` points at `scripts/sync-actions.ts`, but the file
+  lives at `tests/scripts/sync-actions.ts`.
+- That script computes `rootDir = resolve(__dirname, '..')` = `tests/`, so its
+  `actions/...` paths resolve under `tests/`. It is effectively broken and is not
+  run in CI.
+
+**Recommendation:** fix `sync-actions` (path + rootDir) and add a CI
+`sync-actions --check` gate, then regenerate all action copies once. Do this
+before/with B2 so B2's regeneration is reliable. Tracked as a BLOCKER.
+
+## References
+
+- B1 commit: `fix(calculate-version): fall back to nearest reachable tag`
+- Patch 2 branch: `fix/version-final-branch-warning`
+- `src/templates/actions/calculate-version.yml.tpl.ts`
+- `docs/docs/troubleshooting.md` — "No GitHub Release was created after merging a
+  promotion PR"

--- a/src/templates/actions/calculate-version.yml.tpl.ts
+++ b/src/templates/actions/calculate-version.yml.tpl.ts
@@ -178,6 +178,25 @@ runs:
           echo "version=v$VERSION" >> $GITHUB_OUTPUT
         fi
 
+    - name: Get nearest reachable tag
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_new.outputs.version == ''
+      id: get_version_nearest
+      shell: bash
+      run: |
+        # Fallback: when a promotion PR is merged as a merge commit, the release
+        # tag is reachable from HEAD but not directly on it, so the lookups above
+        # miss it and release-it finds no new version. Use the nearest reachable
+        # tag so the release is cut for the promoted version instead of being
+        # silently skipped. No-op in normal flows: this only runs when nothing
+        # else resolved a version.
+        NEAREST=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)
+        if echo "$NEAREST" | grep -qE '^v[0-9]+\\.[0-9]+\\.[0-9]+$'; then
+          echo "Using nearest reachable tag: $NEAREST"
+          echo "version=$NEAREST" >> $GITHUB_OUTPUT
+        else
+          echo "No reachable version tag found"
+        fi
+
     - name: Set version output
       id: set_version
       shell: bash
@@ -191,6 +210,9 @@ runs:
         elif [ -n "\${{ steps.get_version_new.outputs.version }}" ]; then
           echo "Using calculated version: \${{ steps.get_version_new.outputs.version }}"
           echo "version=\${{ steps.get_version_new.outputs.version }}" >> $GITHUB_OUTPUT
+        elif [ -n "\${{ steps.get_version_nearest.outputs.version }}" ]; then
+          echo "Using nearest reachable tag version: \${{ steps.get_version_nearest.outputs.version }}"
+          echo "version=\${{ steps.get_version_nearest.outputs.version }}" >> $GITHUB_OUTPUT
         else
           echo "No version determined"
           echo "version=" >> $GITHUB_OUTPUT

--- a/tests/unit/calculate-version-fallback.test.ts
+++ b/tests/unit/calculate-version-fallback.test.ts
@@ -1,0 +1,84 @@
+/**
+ * calculate-version: nearest-reachable-tag fallback
+ *
+ * When a promotion PR is merged as a merge commit, the release tag is reachable
+ * from HEAD but not directly on it. The exact-tag lookup misses it and
+ * release-it finds no new version, so the version resolves empty and the release
+ * is silently skipped. The fallback uses `git describe --tags --abbrev=0` to
+ * recover the promoted version as a last resort.
+ */
+import type { PinionContext } from '@featherscloud/pinion'
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+import { parse as parseYAML } from 'yaml'
+import { generate as generateCalcVersion } from '../../src/templates/actions/calculate-version.yml.tpl.js'
+import { createWorkspaceWithCleanup, inWorkspace } from '../helpers/workspace.js'
+
+function makeCtx(workspace: string): PinionContext & { config?: Record<string, unknown> } {
+  return {
+    cwd: workspace,
+    argv: ['generate'],
+    config: { actionSourceMode: 'local' },
+    pinion: {
+      logger: { ...console, notice: console.log },
+      prompt: async () => ({}),
+      cwd: workspace,
+      force: true,
+      trace: [],
+      exec: async () => 0
+    }
+  } as PinionContext & { config?: Record<string, unknown> }
+}
+
+describe('calculate-version nearest-reachable-tag fallback', () => {
+  it('generates a fallback step gated behind all prior version lookups', async () => {
+    const [workspace, cleanup] = createWorkspaceWithCleanup('pipecraft-calc-version')
+    try {
+      await inWorkspace(workspace, async () => {
+        await generateCalcVersion(makeCtx(workspace))
+
+        const action = readFileSync('.github/actions/calculate-version/action.yml', 'utf-8')
+
+        // The fallback step exists and uses git describe for the nearest tag
+        expect(action).toContain('id: get_version_nearest')
+        expect(action).toContain('git describe --tags --abbrev=0')
+
+        // It only runs as a last resort: the fallback step's `if` is gated on the
+        // input version, the exact-tag lookup AND the release-it recompute all
+        // being empty.
+        const ifLine = action
+          .split('\n')
+          .find(
+            l =>
+              l.includes("check_input_version.outputs.version == ''") &&
+              l.includes("get_version_old.outputs.version == ''") &&
+              l.includes("get_version_new.outputs.version == ''")
+          )
+        expect(ifLine).toBeDefined()
+
+        // set_version consumes the fallback after the calculated version
+        expect(action).toContain('steps.get_version_nearest.outputs.version')
+        const calcIdx = action.indexOf('Using calculated version')
+        const nearestIdx = action.indexOf('Using nearest reachable tag version')
+        expect(nearestIdx).toBeGreaterThan(calcIdx)
+      })
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('produces valid YAML', async () => {
+    const [workspace, cleanup] = createWorkspaceWithCleanup('pipecraft-calc-version-yaml')
+    try {
+      await inWorkspace(workspace, async () => {
+        await generateCalcVersion(makeCtx(workspace))
+        const content = readFileSync('.github/actions/calculate-version/action.yml', 'utf-8')
+        expect(() => parseYAML(content)).not.toThrow()
+        const doc = parseYAML(content)
+        expect(doc.runs.using).toBe('composite')
+      })
+    } finally {
+      cleanup()
+    }
+  })
+})


### PR DESCRIPTION
Last-resort `git describe` fallback in calculate-version so a merge-commit promotion still cuts the release instead of silently skipping (root cause of silent release skips). Gated to run only when input/exact-tag/release-it all resolve empty — no-op in normal flows. Template + in-sync `actions/` copy regenerated (verified byte-identical to generator). Adds troubleshooting docs on merge method and a B2 design note (docs/plans/version-promotion-threading.md). 2 new tests; 485 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)