### PR TITLE
feat(doctor): detect org-level Actions PR-creation lock

### DIFF
--- a/src/utils/doctor.ts
+++ b/src/utils/doctor.ts
@@ -21,7 +21,9 @@ import { glob } from 'glob'
 import type { PipecraftConfig } from '../types/index.js'
 import { loadConfig, validateConfig } from './config.js'
 import {
+  formatOrgActionsLockMessage,
   getGitHubToken,
+  getOrgWorkflowPermissions,
   getRepositoryInfo,
   getRequiredPermissionChanges,
   getWorkflowPermissions
@@ -281,14 +283,40 @@ export async function checkGitHubPermissions(): Promise<CheckCategory> {
           })
         }
         if (!permissions.can_approve_pull_request_reviews) {
-          results.push({
-            status: 'error',
-            message: 'Cannot create/approve PRs (should be enabled)',
-            fix: {
-              description: 'Enable PR creation permission',
-              command: 'pipecraft setup-github'
+          // Proactively detect an organization-level lock. If the org itself
+          // disallows Actions creating/approving PRs, `pipecraft setup-github`
+          // cannot fix it (the write would 409) — only an org admin can. Surface
+          // that directly instead of recommending a command that will fail.
+          let orgLocked = false
+          try {
+            const orgPermissions = await getOrgWorkflowPermissions(repoInfo.owner, token)
+            if (orgPermissions && orgPermissions.can_approve_pull_request_reviews === false) {
+              orgLocked = true
             }
-          })
+          } catch {
+            // Indeterminate (no org-admin scope, not an org, network) — fall back.
+          }
+
+          if (orgLocked) {
+            results.push({
+              status: 'error',
+              message:
+                'Cannot create/approve PRs — blocked by organization policy (org admin action required)',
+              fix: {
+                description: formatOrgActionsLockMessage(repoInfo.owner),
+                command: `https://github.com/organizations/${repoInfo.owner}/settings/actions`
+              }
+            })
+          } else {
+            results.push({
+              status: 'error',
+              message: 'Cannot create/approve PRs (should be enabled)',
+              fix: {
+                description: 'Enable PR creation permission',
+                command: 'pipecraft setup-github'
+              }
+            })
+          }
         }
       }
     } catch (error: unknown) {

--- a/src/utils/github-setup.ts
+++ b/src/utils/github-setup.ts
@@ -367,23 +367,86 @@ export async function updateWorkflowPermissions(
     const errorText = await response.text()
 
     // Check if this is an organization-level policy conflict
-    if (response.status === 409) {
-      throw new Error(
-        `Organization-level policy prevents changing workflow permissions.\n\n` +
-          `⚠️  This repository's organization has restricted workflow permissions.\n` +
-          `    The organization administrator must:\n\n` +
-          `    1. Visit: https://github.com/organizations/${owner}/settings/actions\n` +
-          `    2. Under "Workflow permissions":\n` +
-          `       - Enable "Read and write permissions"\n` +
-          `       - Check "Allow GitHub Actions to create and approve pull requests"\n` +
-          `    3. Save changes\n\n` +
-          `    Then run 'pipecraft setup-github' again to configure this repository.\n\n` +
-          `API Error: ${errorText}`
-      )
+    if (isOrgActionsPermissionLock(response.status)) {
+      throw new Error(formatOrgActionsLockMessage(owner, errorText))
     }
 
     throw new Error(`Failed to update workflow permissions: ${response.status} ${errorText}`)
   }
+}
+
+/**
+ * Whether an HTTP status from the Actions workflow-permissions API indicates an
+ * organization-level policy lock.
+ *
+ * GitHub returns 409 Conflict when a repository tries to enable a workflow
+ * permission (e.g. "Allow GitHub Actions to create and approve pull requests")
+ * that the parent organization has disabled. The repo-level setting cannot be
+ * changed until an org admin enables it at the organization level.
+ *
+ * @param status - HTTP status code from the GitHub Actions permissions API
+ * @returns true if the status is the org-policy conflict (409)
+ */
+export function isOrgActionsPermissionLock(status: number): boolean {
+  return status === 409
+}
+
+/**
+ * Build an actionable, human-readable message explaining that an organization
+ * policy is blocking the repository's workflow permissions, and exactly how an
+ * org admin can unblock it. Used both by `setup-github` (on a 409 write) and by
+ * `doctor` (when it detects the org-level lock proactively).
+ *
+ * @param owner - Repository owner (the organization name)
+ * @param apiError - Optional raw API error text to append for debugging
+ * @returns A multi-line actionable message
+ */
+export function formatOrgActionsLockMessage(owner: string, apiError?: string): string {
+  const base =
+    `Organization-level policy prevents changing workflow permissions.\n\n` +
+    `⚠️  This repository's organization has restricted workflow permissions.\n` +
+    `    The organization administrator must:\n\n` +
+    `    1. Visit: https://github.com/organizations/${owner}/settings/actions\n` +
+    `    2. Under "Workflow permissions":\n` +
+    `       - Enable "Read and write permissions"\n` +
+    `       - Check "Allow GitHub Actions to create and approve pull requests"\n` +
+    `    3. Save changes\n\n` +
+    `    Then run 'pipecraft setup-github' again to configure this repository.`
+
+  return apiError ? `${base}\n\nAPI Error: ${apiError}` : base
+}
+
+/**
+ * Get organization-level workflow permissions.
+ *
+ * Used to proactively detect an org-level lock from a read-only context (e.g.
+ * `doctor`) without attempting a write that would 409. Returns `null` when the
+ * org endpoint is not accessible — which is the expected case for personal
+ * accounts (404) or tokens lacking org-admin scope (403). Callers should treat
+ * `null` as "indeterminate" and fall back to their default behavior.
+ *
+ * @param org - Organization (owner) name
+ * @param token - GitHub token
+ * @returns The org workflow permissions, or null if not determinable
+ */
+export async function getOrgWorkflowPermissions(
+  org: string,
+  token: string
+): Promise<WorkflowPermissions | null> {
+  const response = await fetch(`https://api.github.com/orgs/${org}/actions/permissions/workflow`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  })
+
+  if (!response.ok) {
+    // 404 (personal account / no such org) or 403 (no admin scope) -> indeterminate
+    return null
+  }
+
+  return response.json()
 }
 
 /**

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the GitHub I/O functions but keep the pure helpers
+// (getRequiredPermissionChanges, formatOrgActionsLockMessage) real so the test
+// asserts the real actionable message.
+vi.mock('../../src/utils/github-setup.js', async importActual => {
+  const actual = await importActual<typeof import('../../src/utils/github-setup.js')>()
+  return {
+    ...actual,
+    getRepositoryInfo: vi.fn(),
+    getGitHubToken: vi.fn(),
+    getWorkflowPermissions: vi.fn(),
+    getOrgWorkflowPermissions: vi.fn()
+  }
+})
+
+import { checkGitHubPermissions } from '../../src/utils/doctor.js'
+import {
+  getGitHubToken,
+  getOrgWorkflowPermissions,
+  getRepositoryInfo,
+  getWorkflowPermissions
+} from '../../src/utils/github-setup.js'
+
+const mockGetRepositoryInfo = getRepositoryInfo as unknown as ReturnType<typeof vi.fn>
+const mockGetGitHubToken = getGitHubToken as unknown as ReturnType<typeof vi.fn>
+const mockGetWorkflowPermissions = getWorkflowPermissions as unknown as ReturnType<typeof vi.fn>
+const mockGetOrgWorkflowPermissions = getOrgWorkflowPermissions as unknown as ReturnType<
+  typeof vi.fn
+>
+
+describe('doctor: checkGitHubPermissions() org-level Actions PR lock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetRepositoryInfo.mockReturnValue({
+      owner: 'my-org',
+      repo: 'monorepo',
+      remote: 'https://github.com/my-org/monorepo.git'
+    })
+    mockGetGitHubToken.mockReturnValue('token123')
+    // repo can write but cannot approve PRs
+    mockGetWorkflowPermissions.mockResolvedValue({
+      default_workflow_permissions: 'write',
+      can_approve_pull_request_reviews: false
+    })
+  })
+
+  it('reports an org-policy lock with actionable org guidance (not a raw setup-github suggestion)', async () => {
+    // org itself disallows Actions creating/approving PRs
+    mockGetOrgWorkflowPermissions.mockResolvedValue({
+      default_workflow_permissions: 'read',
+      can_approve_pull_request_reviews: false
+    })
+
+    const category = await checkGitHubPermissions()
+    const prResult = category.results.find(r => r.message.includes('Cannot create/approve PRs'))
+
+    expect(prResult).toBeDefined()
+    expect(prResult?.status).toBe('error')
+    expect(prResult?.message).toContain('organization policy')
+    // Actionable: points the user at org settings, NOT at `pipecraft setup-github`
+    // (which would fail with a 409 against an org lock)
+    expect(prResult?.fix?.description).toContain('Organization-level policy')
+    expect(prResult?.fix?.command).toContain(
+      'https://github.com/organizations/my-org/settings/actions'
+    )
+    expect(prResult?.fix?.command).not.toBe('pipecraft setup-github')
+  })
+
+  it('falls back to the setup-github suggestion when the lock is repo-level (org check indeterminate)', async () => {
+    // org endpoint not accessible (personal account / no admin scope) -> null
+    mockGetOrgWorkflowPermissions.mockResolvedValue(null)
+
+    const category = await checkGitHubPermissions()
+    const prResult = category.results.find(r => r.message.includes('Cannot create/approve PRs'))
+
+    expect(prResult).toBeDefined()
+    expect(prResult?.status).toBe('error')
+    expect(prResult?.message).toBe('Cannot create/approve PRs (should be enabled)')
+    expect(prResult?.fix?.command).toBe('pipecraft setup-github')
+  })
+})

--- a/tests/unit/github-setup.test.ts
+++ b/tests/unit/github-setup.test.ts
@@ -13,9 +13,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   displaySettingsComparison,
   enableAutoMerge,
+  formatOrgActionsLockMessage,
   getBranchProtection,
   getGitHubToken,
   getMergeCommitSettings,
+  getOrgWorkflowPermissions,
   getRecommendedRepositorySettings,
   getRepositoryInfo,
   getRepositorySettings,
@@ -23,6 +25,7 @@ import {
   getRequiredPermissionChanges,
   getSettingsGaps,
   getWorkflowPermissions,
+  isOrgActionsPermissionLock,
   promptApplySettings,
   promptMergeCommitChanges,
   promptPermissionChanges,
@@ -303,6 +306,86 @@ describe('GitHub Setup', () => {
 
       expect(body).toHaveProperty('default_workflow_permissions', 'write')
       expect(body).not.toHaveProperty('can_approve_pull_request_reviews')
+    })
+
+    it('should throw an actionable org-level message on 409 (org policy lock)', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 409,
+        text: async () =>
+          'The organization does not allow GitHub Actions to create or approve pull requests'
+      } as Response)
+
+      const err = await updateWorkflowPermissions('my-org', 'repo', 'token123', {
+        can_approve_pull_request_reviews: true
+      }).catch((e: unknown) => e as Error)
+
+      expect(err).toBeInstanceOf(Error)
+      // Actionable, not a raw 409
+      expect(err.message).toContain('Organization-level policy')
+      expect(err.message).toContain('https://github.com/organizations/my-org/settings/actions')
+      expect(err.message).toContain('create and approve pull requests')
+    })
+  })
+
+  describe('isOrgActionsPermissionLock()', () => {
+    it('returns true for HTTP 409 (org policy conflict)', () => {
+      expect(isOrgActionsPermissionLock(409)).toBe(true)
+    })
+
+    it('returns false for other statuses', () => {
+      expect(isOrgActionsPermissionLock(403)).toBe(false)
+      expect(isOrgActionsPermissionLock(404)).toBe(false)
+      expect(isOrgActionsPermissionLock(200)).toBe(false)
+    })
+  })
+
+  describe('formatOrgActionsLockMessage()', () => {
+    it('produces an actionable message pointing at org settings', () => {
+      const msg = formatOrgActionsLockMessage('acme-org')
+      expect(msg).toContain('Organization-level policy')
+      expect(msg).toContain('https://github.com/organizations/acme-org/settings/actions')
+      expect(msg).toContain('create and approve pull requests')
+    })
+
+    it('appends the raw API error when provided', () => {
+      const msg = formatOrgActionsLockMessage('acme-org', 'raw 409 body')
+      expect(msg).toContain('raw 409 body')
+    })
+  })
+
+  describe('getOrgWorkflowPermissions()', () => {
+    it('returns org workflow permissions on success', async () => {
+      const orgPerms = {
+        default_workflow_permissions: 'read',
+        can_approve_pull_request_reviews: false
+      }
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => orgPerms
+      } as Response)
+
+      const result = await getOrgWorkflowPermissions('my-org', 'token123')
+
+      expect(result).toEqual(orgPerms)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.github.com/orgs/my-org/actions/permissions/workflow',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer token123' })
+        })
+      )
+    })
+
+    it('returns null when the org endpoint is not accessible (404/403 — personal repo or no admin scope)', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: async () => 'Not Found'
+      } as Response)
+
+      const result = await getOrgWorkflowPermissions('some-user', 'token123')
+      expect(result).toBeNull()
     })
   })
 


### PR DESCRIPTION
`doctor` and `setup-github` now detect when an organization policy blocks *Allow GitHub Actions to create and approve pull requests* and print actionable org-admin guidance instead of a raw 409 / a `setup-github` suggestion that cannot help.

- `github-setup`: reusable `isOrgActionsPermissionLock()` + `formatOrgActionsLockMessage()`; `updateWorkflowPermissions` 409 path refactored to use them; new `getOrgWorkflowPermissions()` for read-only detection.
- `doctor`: when PR-approval permission is missing, proactively checks the org-level setting and surfaces org-admin guidance when the org disallows it.
- 8 new tests (6 github-setup + 2 doctor). Rebased onto develop after #333 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)