### PR TITLE
fix: approve esbuild build scripts (unblock CI install)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli/index.ts",


### PR DESCRIPTION
**Hotfix — develop's required `test-cicd` check is currently red.**

The workflows pin pnpm via `version: latest`; a recent pnpm release made *ignored build scripts* a hard error (`ERR_PNPM_IGNORED_BUILDS`) in CI, so `pnpm install --frozen-lockfile` fails at the install step (esbuild postinstall unapproved). This broke test-cicd on develop and blocks all PRs.

Fix: add `pnpm.onlyBuiltDependencies: ["esbuild"]`. Clean install now runs esbuild's postinstall with no warning; 507 tests pass.

Recommend also pinning pnpm to a fixed version in the workflow templates (separate change) so `latest` can't surprise CI again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)