### PR TITLE
fix(promote-branch): reconcile action copies, unify on autoPromote, fix sync-actions README wipe

### DIFF
--- a/.github/actions/promote-branch/action.yml
+++ b/.github/actions/promote-branch/action.yml
@@ -55,6 +55,12 @@ runs:
         fetch-depth: 0
         token: ${{ inputs.token }}
 
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
     - name: Get Version
       id: get-version
       shell: bash

--- a/.github/actions/promote-branch/action.yml
+++ b/.github/actions/promote-branch/action.yml
@@ -22,8 +22,8 @@ inputs:
     description: 'The original run number from develop branch for traceability'
     required: false
     default: ''
-  autoMerge:
-    description: 'Whether to enable auto-merge for the PR'
+  autoPromote:
+    description: 'Whether to automatically promote (fast-forward) to the target branch'
     required: false
     default: 'false'
   tempBranchPattern:
@@ -50,16 +50,10 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ inputs.token }}
-
-    - name: Configure Git
-      shell: bash
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Get Version
       id: get-version
@@ -157,12 +151,12 @@ runs:
         TARGET="${{ inputs.targetBranch }}"
         SOURCE="${{ inputs.sourceBranch }}"
         VERSION="${{ steps.get-version.outputs.version }}"
-        AUTO_MERGE="${{ inputs.autoMerge }}"
+        AUTO_PROMOTE="${{ inputs.autoPromote }}"
 
         TITLE="🚀 Release $VERSION to $TARGET"
 
         # Determine merge behavior text
-        if [ "$AUTO_MERGE" == "true" ]; then
+        if [ "$AUTO_PROMOTE" == "true" ]; then
           MERGE_TEXT="merge automatically"
         else
           MERGE_TEXT="require manual approval"
@@ -193,7 +187,7 @@ runs:
         fi
 
     - name: Manual Merge Required
-      if: inputs.autoMerge == 'false'
+      if: inputs.autoPromote == 'false'
       shell: bash
       run: |
         PR_NUMBER="${{ steps.check-pr.outputs.prNumber || steps.create-pr.outputs.prNumber }}"
@@ -203,11 +197,11 @@ runs:
         echo "🔗 URL: $PR_URL"
         echo ""
         echo "⚠️  Auto-merge is disabled for this branch."
-        echo "   Review and merge the PR manually when ready (fast-forward)."
-        echo "   Pipecraft uses fast-forward promotion; do not squash or rebase-merge."
+        echo "   Please review and merge the PR manually when ready."
 
     - name: Fast-Forward Merge (Immediate Auto-Merge)
-      if: inputs.autoMerge == 'true'
+      id: fast-forward
+      if: inputs.autoPromote == 'true'
       shell: bash
       run: |
         SOURCE="${{ inputs.sourceBranch }}"
@@ -222,6 +216,11 @@ runs:
 
         # Fetch target branch
         git fetch origin $TARGET:$TARGET 2>/dev/null || true
+
+        # Capture the target branch's current SHA BEFORE fast-forward (for change detection)
+        BEFORE_SHA=$(git rev-parse $TARGET)
+        echo "beforeSha=$BEFORE_SHA" >> $GITHUB_OUTPUT
+        echo "Target before: $BEFORE_SHA"
 
         # Checkout target branch
         git checkout $TARGET
@@ -245,7 +244,7 @@ runs:
         echo "📝 PR will be closed automatically for audit trail"
 
     - name: Wait for Branch to Propagate
-      if: inputs.autoMerge == 'true'
+      if: inputs.autoPromote == 'true'
       shell: bash
       run: |
         echo "⏳ Waiting 5 seconds for branch update to propagate..."
@@ -253,7 +252,7 @@ runs:
         echo "✅ Branch should be fully propagated"
 
     - name: Trigger Pipeline Workflow on Target Branch
-      if: inputs.autoMerge == 'true'
+      if: inputs.autoPromote == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -261,18 +260,20 @@ runs:
         TARGET="${{ inputs.targetBranch }}"
         VERSION="${{ steps.get-version.outputs.version }}"
         RUN_NUMBER="${{ inputs.run_number }}"
+        BEFORE_SHA="${{ steps.fast-forward.outputs.beforeSha }}"
 
         # Get the exact commit SHA that was just pushed to target branch
         COMMIT_SHA=$(git rev-parse $TARGET)
         echo "🔄 Triggering pipeline workflow on $TARGET branch"
         echo "   Version: $VERSION"
         echo "   Commit SHA: $COMMIT_SHA"
+        echo "   Before SHA: $BEFORE_SHA (for change detection)"
 
         # Trigger the pipeline workflow on the target branch
         # This is necessary because GITHUB_TOKEN pushes don't trigger workflows by default
         # Pass the exact commit SHA to ensure the workflow checks out the correct commit
-        # (avoids race conditions from GitHub's eventual consistency)
-        WORKFLOW_ARGS=(--ref "$TARGET" --field version="$VERSION" --field commitSha="$COMMIT_SHA")
+        # Pass beforeSha for accurate change detection (simulates push event's 'before' field)
+        WORKFLOW_ARGS=(--ref "$TARGET" --field version="$VERSION" --field commitSha="$COMMIT_SHA" --field beforeSha="$BEFORE_SHA")
         if [ -n "$RUN_NUMBER" ]; then
           WORKFLOW_ARGS+=(--field run_number="$RUN_NUMBER")
           echo "   Run number: $RUN_NUMBER (for traceability)"
@@ -283,7 +284,7 @@ runs:
         echo "✅ Pipeline workflow triggered on $TARGET with version $VERSION at commit $COMMIT_SHA"
 
     - name: Close PR and Delete Branch
-      if: inputs.autoMerge == 'true'
+      if: inputs.autoPromote == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -314,4 +315,4 @@ runs:
         echo "ℹ️  Using existing PR #$PR_NUMBER"
         echo "🔗 URL: $PR_URL"
 
-        # Note: Fast-forward merge happens in separate step if autoMerge is enabled
+        # Note: Fast-forward merge happens in separate step if autoPromote is enabled

--- a/.github/workflows/test-promote-branch.yml
+++ b/.github/workflows/test-promote-branch.yml
@@ -60,7 +60,7 @@ jobs:
           sourceBranch: ${{ steps.setup.outputs.source }}
           targetBranch: ${{ steps.setup.outputs.target }}
           version: v0.0.0-test-${{ github.run_number }}
-          autoMerge: 'false'
+          autoPromote: 'false'
 
       - name: Verify PR Created
         env:
@@ -163,7 +163,7 @@ jobs:
           sourceBranch: ${{ steps.setup.outputs.source }}
           targetBranch: ${{ steps.setup.outputs.target }}
           version: v0.0.0-test-${{ github.run_number }}
-          autoMerge: 'true'
+          autoPromote: 'true'
 
       - name: Verify Fast-Forward Merge
         run: |
@@ -275,7 +275,7 @@ jobs:
         with:
           sourceBranch: ${{ steps.setup.outputs.source }}
           targetBranch: ${{ steps.setup.outputs.target }}
-          autoMerge: 'false'
+          autoPromote: 'false'
           # version not provided - should auto-detect
 
       - name: Verify Version Detected
@@ -367,7 +367,7 @@ jobs:
           targetBranch: ${{ steps.setup.outputs.target }}
           version: '1.0.0'
           tempBranchPattern: 'custom-release/{version}-{target}'
-          autoMerge: 'false'
+          autoPromote: 'false'
 
       - name: Verify Custom Pattern
         run: |
@@ -447,7 +447,7 @@ jobs:
           sourceBranch: ${{ steps.setup.outputs.source }}
           targetBranch: ${{ steps.setup.outputs.target }}
           version: v0.0.0-test-${{ github.run_number }}
-          autoMerge: 'false'
+          autoPromote: 'false'
 
       - name: Second Promotion (Should Use Existing PR)
         id: second-promote
@@ -456,7 +456,7 @@ jobs:
           sourceBranch: ${{ steps.setup.outputs.source }}
           targetBranch: ${{ steps.setup.outputs.target }}
           version: v0.0.0-test-${{ github.run_number }}
-          autoMerge: 'false'
+          autoPromote: 'false'
 
       - name: Verify Same PR Used
         run: |

--- a/actions/calculate-version/action.yml
+++ b/actions/calculate-version/action.yml
@@ -29,13 +29,13 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.commitSha || github.sha }}
         fetch-depth: 0
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/actions/create-pr/action.yml
+++ b/actions/create-pr/action.yml
@@ -35,7 +35,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ inputs.token }}

--- a/actions/create-release/action.yml
+++ b/actions/create-release/action.yml
@@ -31,7 +31,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.commitSha || github.sha }}
         fetch-depth: 0

--- a/actions/manage-branch/action.yml
+++ b/actions/manage-branch/action.yml
@@ -28,7 +28,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ inputs.token }}

--- a/actions/promote-branch/action.yml
+++ b/actions/promote-branch/action.yml
@@ -2,6 +2,10 @@ name: 'Promote Branch'
 description: 'Promote code from source to target branch via temporary branch + PR'
 author: 'PipeCraft'
 
+branding:
+  icon: 'git-merge'
+  color: 'purple'
+
 inputs:
   sourceBranch:
     description: 'Source branch to promote from (defaults to github.ref_name)'
@@ -33,11 +37,11 @@ inputs:
 
 outputs:
   prNumber:
-    description: 'The created PR number'
-    value: ${{ steps.create-pr.outputs.prNumber }}
+    description: 'The created or existing PR number'
+    value: ${{ steps.check-pr.outputs.prNumber || steps.create-pr.outputs.prNumber }}
   prUrl:
-    description: 'The created PR URL'
-    value: ${{ steps.create-pr.outputs.prUrl }}
+    description: 'The created or existing PR URL'
+    value: ${{ steps.check-pr.outputs.prUrl || steps.create-pr.outputs.prUrl }}
   tempBranch:
     description: 'The temporary branch name'
     value: ${{ steps.create-temp.outputs.tempBranch }}
@@ -46,7 +50,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ inputs.token }}

--- a/actions/promote-branch/action.yml
+++ b/actions/promote-branch/action.yml
@@ -55,6 +55,12 @@ runs:
         fetch-depth: 0
         token: ${{ inputs.token }}
 
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
     - name: Get Version
       id: get-version
       shell: bash

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -160,7 +160,7 @@ The command handles three types of configuration:
 
 **Workflow Permissions**: Your workflows need write access to create tags and push changes. The command updates your default workflow permissions from read-only to read-write and enables the ability for workflows to create and approve pull requests.
 
-**Repository Auto-Merge**: For branch promotion flows that use auto-merge, this feature must be enabled at the repository level.
+**Repository Auto-Promote**: For branch promotion flows that use auto-merge, this feature must be enabled at the repository level.
 
 **Branch Protection**: Branches configured with auto-merge require basic branch protection rules. The command sets up these rules with sensible defaults: status checks enabled, linear history required, and protection against force pushes.
 

--- a/docs/docs/docs-index.md
+++ b/docs/docs/docs-index.md
@@ -35,7 +35,7 @@ PipeCraft documentation is organized into user-facing guides, contributor resour
 - **[Current Trunk Flow](/docs/flows/trunk-flow)** - The ONE currently implemented workflow pattern
 
   - How promotions work (develop → staging → main)
-  - Auto-merge configuration
+  - Auto-promote configuration
   - Domain-based testing
   - Semantic versioning integration
 

--- a/docs/docs/flows/trunk-flow.md
+++ b/docs/docs/flows/trunk-flow.md
@@ -59,12 +59,12 @@ feature → develop → staging → main
 }
 ```
 
-#### Auto-Merge Configuration
+#### Auto-Promote Configuration
 
 ```json
 {
-  "autoMerge": {
-    "staging": true, // Auto-merge develop → staging PRs
+  "autoPromote": {
+    "staging": true, // Auto-promote develop → staging PRs
     "main": false // Manual approval for staging → main
   },
   "mergeMethod": {
@@ -74,9 +74,9 @@ feature → develop → staging → main
 }
 ```
 
-**Auto-Merge Behavior**:
+**Auto-Promote Behavior**:
 
-- When `autoMerge` is `true` for a branch, PRs targeting that branch are automatically merged after checks pass
+- When `autoPromote` is `true` for a branch, PRs targeting that branch are automatically merged after checks pass
 - When `false`, PRs require manual approval
 - Typically used for automated promote-to-staging, manual promote-to-production
 
@@ -414,7 +414,7 @@ The following GitHub settings must be configured (can use `pipecraft setup`):
 
 - **Branch Protection**: Require status checks before merging
 - **Workflow Permissions**: Allow workflow to create PRs
-- **Auto-Merge**: Enable auto-merge for the repository
+- **Auto-Promote**: Enable auto-merge for the repository
 
 ### Git Workflow Constraints
 
@@ -458,7 +458,7 @@ The following GitHub settings must be configured (can use `pipecraft setup`):
   "initialBranch": "develop",
   "finalBranch": "main",
   "branchFlow": ["develop", "staging", "main"],
-  "autoMerge": {
+  "autoPromote": {
     "staging": true,
     "main": false
   },
@@ -527,13 +527,13 @@ git branch --show-current
 # Should match one of branchFlow values
 ```
 
-### Auto-Merge Not Working
+### Auto-Promote Not Working
 
 **Symptom**: PRs created but not automatically merged
 
 **Causes**:
 
-1. Auto-merge not enabled in repo settings
+1. Auto-promote not enabled in repo settings
 2. Branch protection rules blocking
 3. Required checks not passing
 4. Insufficient permissions

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -75,7 +75,7 @@ After answering these questions, you'll have a `.pipecraftrc.json` file:
   "finalBranch": "main",
   "branchFlow": ["develop", "staging", "main"],
   "packageManager": "npm",
-  "autoMerge": {
+  "autoPromote": {
     "staging": true,
     "main": true
   },

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -487,7 +487,7 @@ The `setup-github` command configures:
    - Default workflow permissions: **write** (for creating tags and pushing changes)
    - Can create/approve pull requests: **Yes** (for automated PR creation)
 
-2. **Repository Auto-Merge**
+2. **Repository Auto-Promote**
 
    - Enables auto-merge feature at repository level
    - Required for automatic promotion between branches
@@ -512,7 +512,7 @@ The command will:
 
 1. Check your current repository permissions
 2. Enable repository-level auto-merge if needed
-3. Configure branch protection for branches with `autoMerge: true` in config
+3. Configure branch protection for branches with `autoPromote: true` in config
 4. Prompt you to apply each change
 5. Update the settings if you accept
 
@@ -619,7 +619,7 @@ You can also configure these settings manually:
    - Check **Allow GitHub Actions to create and approve pull requests**
 4. Click **Save**
 
-**Repository Auto-Merge:**
+**Repository Auto-Promote:**
 
 1. Navigate to **Settings** → **General**
 2. Scroll to "Pull Requests"

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -72,7 +72,7 @@ resolved on the final branch's `HEAD`. If the promotion PR is merged as a
 **merge commit**, the version tag is not on the final branch's `HEAD`, so the
 version resolves empty and the release is skipped.
 
-When `autoMerge` is disabled for the final branch (human-gated production
+When `autoPromote` is disabled for the final branch (human-gated production
 promotion), merge promotion PRs using **fast-forward** or **rebase**, not a
 merge commit:
 

--- a/src/templates/actions/promote-branch.yml.tpl.ts
+++ b/src/templates/actions/promote-branch.yml.tpl.ts
@@ -25,6 +25,10 @@ const promoteBranchActionTemplate = (ctx: any) => {
     description: 'Promote code from source to target branch via temporary branch + PR'
     author: 'PipeCraft'
 
+    branding:
+      icon: 'git-merge'
+      color: 'purple'
+
     inputs:
       sourceBranch:
         description: 'Source branch to promote from (defaults to github.ref_name)'
@@ -56,11 +60,11 @@ const promoteBranchActionTemplate = (ctx: any) => {
 
     outputs:
       prNumber:
-        description: 'The created PR number'
-        value: \${{ steps.create-pr.outputs.prNumber }}
+        description: 'The created or existing PR number'
+        value: \${{ steps.check-pr.outputs.prNumber || steps.create-pr.outputs.prNumber }}
       prUrl:
-        description: 'The created PR URL'
-        value: \${{ steps.create-pr.outputs.prUrl }}
+        description: 'The created or existing PR URL'
+        value: \${{ steps.check-pr.outputs.prUrl || steps.create-pr.outputs.prUrl }}
       tempBranch:
         description: 'The temporary branch name'
         value: \${{ steps.create-temp.outputs.tempBranch }}

--- a/src/templates/actions/promote-branch.yml.tpl.ts
+++ b/src/templates/actions/promote-branch.yml.tpl.ts
@@ -78,6 +78,12 @@ const promoteBranchActionTemplate = (ctx: any) => {
             fetch-depth: 0
             token: \${{ inputs.token }}
 
+        - name: Configure Git
+          shell: bash
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
         - name: Get Version
           id: get-version
           shell: bash

--- a/tests/scripts/sync-actions.ts
+++ b/tests/scripts/sync-actions.ts
@@ -101,10 +101,12 @@ function generateActionsFromTemplates(): void {
       const sourceDir = path.join(generatedActionsDir, action.name)
       const targetDir = path.join(targetActionsDir, action.name)
       if (fs.existsSync(sourceDir)) {
-        if (fs.existsSync(targetDir)) {
-          fs.rmSync(targetDir, { recursive: true, force: true })
+        // Overwrite only generated files (action.yml); preserve hand-authored
+        // extras like README.md instead of wiping the whole directory.
+        fs.mkdirSync(targetDir, { recursive: true })
+        for (const file of fs.readdirSync(sourceDir)) {
+          fs.cpSync(path.join(sourceDir, file), path.join(targetDir, file), { recursive: true })
         }
-        fs.cpSync(sourceDir, targetDir, { recursive: true })
         console.log(`   ✅ ${action.name}`)
       }
     }


### PR DESCRIPTION
Reconciles the promote-branch divergence and fixes related drift/tooling:

- **Template**: adds branding; fixes `outputs.prNumber/prUrl` to fall back to the existing-PR check (was empty on re-promotion — a real bug in the canonical source action).
- **Unify on `autoPromote`** (pipecraft's canonical; config/pipeline/template all use it). Realigns the `.github/actions` copy and `test-promote-branch.yml` off the diverged `autoMerge` (#207).
- **Drift**: regenerates the source action copies, completing #334's Node-24 `checkout/setup-node@v4→v5` that left calculate-version/create-pr/create-release/manage-branch stale. `sync-actions:check` now green for all 7.
- **sync-actions tool**: stop wiping the action dir (it deleted hand-authored README.md); overwrite only generated files.

507 tests pass; promote-branch test workflow dispatched for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)