### PR TITLE
feat(config): runtime config for Node/pnpm versions (retire the pnpm pin)

### DIFF
--- a/.pipecraftrc
+++ b/.pipecraftrc
@@ -12,6 +12,11 @@ mergeStrategy: fast-forward
 # Enforce conventional commit messages (feat:, fix:, etc.)
 requireConventionalCommits: true
 
+# Runtime tool versions for generated CI/CD workflows
+runtime:
+  nodeVersion: '22'
+  pnpmVersion: '10.6.2' # pin pnpm 10.x; pnpm 11 changed build-script approval (ERR_PNPM_IGNORED_BUILDS)
+
 # Branch flow configuration
 initialBranch: develop  # Where features land
 finalBranch: main       # Production branch

--- a/docs/docs/configuration-reference.md
+++ b/docs/docs/configuration-reference.md
@@ -142,6 +142,40 @@ Use explicit configuration when:
 }
 ```
 
+### runtime
+
+**Type**: `object`
+**Required**: No
+**Default**: `{ nodeVersion: '22', pnpmVersion: '10' }`
+
+Controls the Node.js and pnpm versions used in generated CI/CD workflows, so you can pin or bump them from config instead of hand-editing `pipeline.yml`.
+
+```json
+{
+  "runtime": {
+    "nodeVersion": "22",
+    "pnpmVersion": "10"
+  }
+}
+```
+
+**Properties:**
+
+- **nodeVersion** (`string`, optional): Node.js version for workflows. Accepts a major (e.g. `'22'`, `'24'`) or an exact version (e.g. `'22.18.0'`). Default: `'22'`.
+- **pnpmVersion** (`string`, optional): pnpm version for workflows (used when the project installs with pnpm). Accepts a major (e.g. `'10'`) or an exact version (e.g. `'10.6.2'`). Default: `'10'`.
+
+**Impact on generated workflows:**
+
+- Sets the `NODE_VERSION` and `PNPM_VERSION` env vars in `pipeline.yml`
+- The `version` job passes `NODE_VERSION` into the `calculate-version` action
+
+**Authority and preservation:**
+
+- When a value is set in `runtime`, it is **authoritative** — regeneration overwrites the corresponding env var with the configured value.
+- When unset, the existing value in `pipeline.yml` is **preserved**, falling back to the defaults on first generation.
+
+> Tip: pin `pnpmVersion` (e.g. `'10'`) to avoid `pnpm/action-setup`'s `latest` pulling a major release with breaking changes into CI.
+
 ### initialBranch
 
 **Type**: `string`

--- a/src/templates/workflows/pipeline.yml.tpl.ts
+++ b/src/templates/workflows/pipeline.yml.tpl.ts
@@ -226,8 +226,13 @@ export const generate = (ctx: PathBasedPipelineContext) =>
         // Header (name, run-name, on triggers)
         ...createHeaderOperations({
           branchFlow,
-          nodeVersion: (existingEnv?.NODE_VERSION as string | undefined) ?? undefined,
-          pnpmVersion: (existingEnv?.PNPM_VERSION as string | undefined) ?? undefined
+          // config.runtime is authoritative; fall back to the existing file's env
+          nodeVersion:
+            config.runtime?.nodeVersion ?? (existingEnv?.NODE_VERSION as string | undefined),
+          pnpmVersion:
+            config.runtime?.pnpmVersion ?? (existingEnv?.PNPM_VERSION as string | undefined),
+          nodeVersionFromConfig: typeof config.runtime?.nodeVersion === 'string',
+          pnpmVersionFromConfig: typeof config.runtime?.pnpmVersion === 'string'
         }),
 
         // Changes detection (path-based)

--- a/src/templates/workflows/shared/operations-header.ts
+++ b/src/templates/workflows/shared/operations-header.ts
@@ -11,22 +11,30 @@ import type { PathOperationConfig } from '../../../utils/ast-path-operations.js'
 export interface HeaderContext {
   branchFlow: string[]
   /**
-   * Existing node version from the pipeline, if present.
+   * Node version for the pipeline (from config.runtime, or the existing file).
    * Falls back to PipeCraft defaults when not provided.
    */
   nodeVersion?: string
   /**
-   * Existing pnpm version from the pipeline, if present.
+   * pnpm version for the pipeline (from config.runtime, or the existing file).
    * Falls back to PipeCraft defaults when not provided.
    */
   pnpmVersion?: string
+  /**
+   * When true, nodeVersion came from config.runtime and is authoritative:
+   * regeneration overwrites env.NODE_VERSION instead of preserving the existing
+   * value. When false/undefined the existing value is preserved.
+   */
+  nodeVersionFromConfig?: boolean
+  /** As nodeVersionFromConfig, for env.PNPM_VERSION. */
+  pnpmVersionFromConfig?: boolean
 }
 
 /**
  * Create workflow header operations (name, run-name, on triggers)
  */
 export function createHeaderOperations(ctx: HeaderContext): PathOperationConfig[] {
-  const { branchFlow, nodeVersion, pnpmVersion } = ctx
+  const { branchFlow, nodeVersion, pnpmVersion, nodeVersionFromConfig, pnpmVersionFromConfig } = ctx
   // Provide sensible defaults if branchFlow is invalid
   const validBranchFlow =
     branchFlow && Array.isArray(branchFlow) && branchFlow.length > 0 ? branchFlow : ['main']
@@ -34,7 +42,7 @@ export function createHeaderOperations(ctx: HeaderContext): PathOperationConfig[
   const normalizedNodeVersion =
     typeof nodeVersion === 'string' && nodeVersion.trim().length > 0 ? nodeVersion.trim() : '22'
   const normalizedPnpmVersion =
-    typeof pnpmVersion === 'string' && pnpmVersion.trim().length > 0 ? pnpmVersion.trim() : '9'
+    typeof pnpmVersion === 'string' && pnpmVersion.trim().length > 0 ? pnpmVersion.trim() : '10'
 
   return [
     // =============================================================================
@@ -116,14 +124,15 @@ Runtime versions
       required: true
     },
     {
+      // config.runtime is authoritative (overwrite); otherwise preserve existing
       path: 'env.NODE_VERSION',
-      operation: 'preserve',
+      operation: nodeVersionFromConfig ? 'overwrite' : 'preserve',
       value: new Scalar(normalizedNodeVersion),
       required: true
     },
     {
       path: 'env.PNPM_VERSION',
-      operation: 'preserve',
+      operation: pnpmVersionFromConfig ? 'overwrite' : 'preserve',
       value: new Scalar(normalizedPnpmVersion),
       required: true
     },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -220,6 +220,36 @@ export interface PipecraftConfig {
   packageManager?: 'npm' | 'yarn' | 'pnpm'
 
   /**
+   * Runtime tool versions for generated CI/CD workflows.
+   *
+   * Controls the `NODE_VERSION` / `PNPM_VERSION` workflow env vars (and the
+   * version job's `node-version`) without hand-editing generated files. When a
+   * value is set here it is authoritative — regeneration overwrites the env var
+   * with the configured value; when unset, the existing value is preserved and
+   * falls back to the defaults.
+   *
+   * @example
+   * ```typescript
+   * runtime: { nodeVersion: '22', pnpmVersion: '10' }
+   * ```
+   */
+  runtime?: {
+    /**
+     * Node.js version for workflows. Accepts a major (e.g. `'22'`) or an exact
+     * version (e.g. `'22.18.0'`).
+     * @default '22'
+     */
+    nodeVersion?: string
+
+    /**
+     * pnpm version for workflows (used when the project installs with pnpm).
+     * Accepts a major (e.g. `'10'`) or an exact version (e.g. `'10.6.2'`).
+     * @default '10'
+     */
+    pnpmVersion?: string
+  }
+
+  /**
    * How workflows should reference PipeCraft actions.
    *
    * - 'local': Actions copied to ./.github/actions/ (default, full control)

--- a/tests/snapshots/__snapshots__/workflow-snapshots.test.ts.snap
+++ b/tests/snapshots/__snapshots__/workflow-snapshots.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Workflow Snapshots > Config: minimal > should match snapshot 1`] = `
 
 #Runtime versions
 # Update these to match your project's requirements without regenerating workflows
-  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "9" } },
+  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "10" } },
 
   on: { workflow_dispatch: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, workflow_call: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, push: { branches: [ develop, main ] }, pull_request: { types: [ opened, synchronize, reopened ], branches: [ develop ] } },
   jobs:
@@ -103,7 +103,7 @@ exports[`Workflow Snapshots > Config: multi-domain > should match snapshot 1`] =
 
 #Runtime versions
 # Update these to match your project's requirements without regenerating workflows
-  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "9" } },
+  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "10" } },
 
   on: { workflow_dispatch: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, workflow_call: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, push: { branches: [ develop, main ] }, pull_request: { types: [ opened, synchronize, reopened ], branches: [ develop ] } },
   jobs:
@@ -211,7 +211,7 @@ exports[`Workflow Snapshots > Config: remote-actions > should match snapshot 1`]
 
 #Runtime versions
 # Update these to match your project's requirements without regenerating workflows
-  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "9" } },
+  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "10" } },
 
   on: { workflow_dispatch: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, workflow_call: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, push: { branches: [ develop, main ] }, pull_request: { types: [ opened, synchronize, reopened ], branches: [ develop ] } },
   jobs:
@@ -309,7 +309,7 @@ exports[`Workflow Snapshots > Config: single-branch > should match snapshot 1`] 
 
 #Runtime versions
 # Update these to match your project's requirements without regenerating workflows
-  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "9" } },
+  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "10" } },
 
   on: { workflow_dispatch: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, workflow_call: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, push: { branches: [ main ] }, pull_request: { types: [ opened, synchronize, reopened ], branches: [ main ] } },
   jobs:
@@ -403,7 +403,7 @@ exports[`Workflow Snapshots > Config: three-branch > should match snapshot 1`] =
 
 #Runtime versions
 # Update these to match your project's requirements without regenerating workflows
-  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "9" } },
+  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "10" } },
 
   on: { workflow_dispatch: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, workflow_call: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, push: { branches: [ develop, staging, main ] }, pull_request: { types: [ opened, synchronize, reopened ], branches: [ develop ] } },
   jobs:
@@ -505,7 +505,7 @@ exports[`Workflow Snapshots > Config: with-auto-merge > should match snapshot 1`
 
 #Runtime versions
 # Update these to match your project's requirements without regenerating workflows
-  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "9" } },
+  env: { FETCH_DEPTH_AFFECTED: { value: "100" }, FETCH_DEPTH_VERSIONING: { value: "0" }, NODE_VERSION: { value: "22" }, PNPM_VERSION: { value: "10" } },
 
   on: { workflow_dispatch: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, workflow_call: { inputs: { version: { description: The version to deploy, required: false, type: string }, baseRef: { description: The base reference for comparison, required: false, type: string }, run_number: { description: The original run number from develop branch, required: false, type: string }, commitSha: { description: The exact commit SHA to checkout and test, required: false, type: string }, beforeSha: { description: The commit SHA before promotion (for change detection), required: false, type: string } } }, push: { branches: [ develop, staging, main ] }, pull_request: { types: [ opened, synchronize, reopened ], branches: [ develop ] } },
   jobs:

--- a/tests/unit/runtime-config.test.ts
+++ b/tests/unit/runtime-config.test.ts
@@ -1,0 +1,51 @@
+/**
+ * runtime config -> pipeline env versions
+ *
+ * config.runtime.{nodeVersion,pnpmVersion} drives the NODE_VERSION / PNPM_VERSION
+ * workflow env vars. When provided in config the values are authoritative
+ * (overwrite on regeneration); otherwise the existing value is preserved and
+ * falls back to defaults.
+ */
+import { describe, expect, it } from 'vitest'
+import { createHeaderOperations } from '../../src/templates/workflows/shared/operations-header.js'
+
+function findOp(ops: ReturnType<typeof createHeaderOperations>, path: string) {
+  return ops.find(o => o.path === path)
+}
+
+function scalarValue(op: { value?: unknown } | undefined): string {
+  const v = op?.value as { value?: unknown } | string | undefined
+  return String((v && typeof v === 'object' && 'value' in v ? v.value : v) ?? '')
+}
+
+describe('runtime config -> pipeline env versions', () => {
+  it('overwrites NODE_VERSION/PNPM_VERSION when config.runtime provides them', () => {
+    const ops = createHeaderOperations({
+      branchFlow: ['develop', 'main'],
+      nodeVersion: '24',
+      pnpmVersion: '10.6.2',
+      nodeVersionFromConfig: true,
+      pnpmVersionFromConfig: true
+    })
+
+    const node = findOp(ops, 'env.NODE_VERSION')
+    const pnpm = findOp(ops, 'env.PNPM_VERSION')
+
+    expect(node?.operation).toBe('overwrite')
+    expect(scalarValue(node)).toBe('24')
+    expect(pnpm?.operation).toBe('overwrite')
+    expect(scalarValue(pnpm)).toBe('10.6.2')
+  })
+
+  it('preserves and falls back to defaults (node 22, pnpm 10) when not config-driven', () => {
+    const ops = createHeaderOperations({ branchFlow: ['develop', 'main'] })
+
+    const node = findOp(ops, 'env.NODE_VERSION')
+    const pnpm = findOp(ops, 'env.PNPM_VERSION')
+
+    expect(node?.operation).toBe('preserve')
+    expect(scalarValue(node)).toBe('22')
+    expect(pnpm?.operation).toBe('preserve')
+    expect(scalarValue(pnpm)).toBe('10')
+  })
+})


### PR DESCRIPTION
Adds a `runtime` config block (`nodeVersion`/`pnpmVersion`) so workflow tool versions come from `.pipecraftrc` instead of hand-editing `pipeline.yml`. Proper version of the docs-only #270 (closed); lets the temporary pnpm 10.6.2 CI pin become config-driven.

- Config-set values are authoritative (overwrite on regen); unset preserved, default node `22` / pnpm `10`.
- version job already passes NODE_VERSION into calculate-version.
- Default pnpm `9`→`10` (avoids action-setup `latest` → pnpm 11 build-approval break).
- Dogfooded in pipecraft's own .pipecraftrc.

509 tests; config validates; generate confirmed driving env end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)