### PR TITLE
chore(docs): make typedoc API generation deterministic

### DIFF
--- a/docs/docs/api/generators/init.tpl.md
+++ b/docs/docs/api/generators/init.tpl.md
@@ -37,7 +37,7 @@ respect user input and allow customization.
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [generators/init.tpl.ts:338](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/generators/init.tpl.ts#L338)
+Defined in: [generators/init.tpl.ts:338](https://github.com/the-craftlab/pipecraft/blob/main/src/generators/init.tpl.ts#L338)
 
 Init generator main entry point.
 

--- a/docs/docs/api/generators/workflows.tpl.md
+++ b/docs/docs/api/generators/workflows.tpl.md
@@ -49,7 +49,7 @@ await generate({
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [generators/workflows.tpl.ts:137](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/generators/workflows.tpl.ts#L137)
+Defined in: [generators/workflows.tpl.ts:137](https://github.com/the-craftlab/pipecraft/blob/main/src/generators/workflows.tpl.ts#L137)
 
 Workflows generator main entry point.
 

--- a/docs/docs/api/templates/actions/calculate-version.yml.tpl.md
+++ b/docs/docs/api/templates/actions/calculate-version.yml.tpl.md
@@ -47,7 +47,7 @@ jobs:
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/calculate-version.yml.tpl.ts:233](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/calculate-version.yml.tpl.ts#L233)
+Defined in: [templates/actions/calculate-version.yml.tpl.ts:233](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/calculate-version.yml.tpl.ts#L233)
 
 Generator entry point for calculate-version composite action.
 

--- a/docs/docs/api/templates/actions/create-pr.yml.tpl.md
+++ b/docs/docs/api/templates/actions/create-pr.yml.tpl.md
@@ -13,7 +13,7 @@ automating branch promotion in trunk-based development workflows.
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/create-pr.yml.tpl.ts:160](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/create-pr.yml.tpl.ts#L160)
+Defined in: [templates/actions/create-pr.yml.tpl.ts:160](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/create-pr.yml.tpl.ts#L160)
 
 Generator entry point for create-pr composite action.
 

--- a/docs/docs/api/templates/actions/create-release.yml.tpl.md
+++ b/docs/docs/api/templates/actions/create-release.yml.tpl.md
@@ -14,7 +14,7 @@ after successful version calculation and tagging.
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/create-release.yml.tpl.ts:142](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/create-release.yml.tpl.ts#L142)
+Defined in: [templates/actions/create-release.yml.tpl.ts:142](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/create-release.yml.tpl.ts#L142)
 
 Generator entry point for create-release composite action.
 

--- a/docs/docs/api/templates/actions/create-tag.yml.tpl.md
+++ b/docs/docs/api/templates/actions/create-tag.yml.tpl.md
@@ -13,7 +13,7 @@ GitHub releases. Used after version calculation to tag the codebase with semanti
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/create-tag.yml.tpl.ts:126](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/create-tag.yml.tpl.ts#L126)
+Defined in: [templates/actions/create-tag.yml.tpl.ts:126](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/create-tag.yml.tpl.ts#L126)
 
 Generator entry point for create-tag composite action.
 

--- a/docs/docs/api/templates/actions/detect-changes.yml.tpl.md
+++ b/docs/docs/api/templates/actions/detect-changes.yml.tpl.md
@@ -28,7 +28,7 @@ This allows the same action to work with any domain configuration without regene
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/detect-changes.yml.tpl.ts:210](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/detect-changes.yml.tpl.ts#L210)
+Defined in: [templates/actions/detect-changes.yml.tpl.ts:210](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/detect-changes.yml.tpl.ts#L210)
 
 Generator entry point for detect-changes composite action.
 

--- a/docs/docs/api/templates/actions/manage-branch.yml.tpl.md
+++ b/docs/docs/api/templates/actions/manage-branch.yml.tpl.md
@@ -13,7 +13,7 @@ branch creation, and deletion. Core utility for trunk-based development workflow
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/manage-branch.yml.tpl.ts:145](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/manage-branch.yml.tpl.ts#L145)
+Defined in: [templates/actions/manage-branch.yml.tpl.ts:145](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/manage-branch.yml.tpl.ts#L145)
 
 Generator entry point for manage-branch composite action.
 

--- a/docs/docs/api/templates/actions/promote-branch.yml.tpl.md
+++ b/docs/docs/api/templates/actions/promote-branch.yml.tpl.md
@@ -13,7 +13,7 @@ temporary branch and pull request. Handles auto-merge and cleanup for trunk flow
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/actions/promote-branch.yml.tpl.ts:361](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/actions/promote-branch.yml.tpl.ts#L361)
+Defined in: [templates/actions/promote-branch.yml.tpl.ts:361](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/actions/promote-branch.yml.tpl.ts#L361)
 
 Generator entry point for promote-branch composite action.
 

--- a/docs/docs/api/templates/release-it.cjs.tpl.md
+++ b/docs/docs/api/templates/release-it.cjs.tpl.md
@@ -20,7 +20,7 @@ This template creates a release-it configuration that:
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/release-it.cjs.tpl.ts:155](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/release-it.cjs.tpl.ts#L155)
+Defined in: [templates/release-it.cjs.tpl.ts:155](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/release-it.cjs.tpl.ts#L155)
 
 Release-It configuration generator
 

--- a/docs/docs/api/templates/workflows/enforce-pr-target.yml.tpl.md
+++ b/docs/docs/api/templates/workflows/enforce-pr-target.yml.tpl.md
@@ -35,7 +35,7 @@ await generate({
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/workflows/enforce-pr-target.yml.tpl.ts:54](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/enforce-pr-target.yml.tpl.ts#L54)
+Defined in: [templates/workflows/enforce-pr-target.yml.tpl.ts:54](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/enforce-pr-target.yml.tpl.ts#L54)
 
 Generates the enforce-pr-target.yml workflow file.
 

--- a/docs/docs/api/templates/workflows/pipeline.yml.tpl.md
+++ b/docs/docs/api/templates/workflows/pipeline.yml.tpl.md
@@ -8,7 +8,7 @@
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/workflows/pipeline.yml.tpl.ts:197](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/pipeline.yml.tpl.ts#L197)
+Defined in: [templates/workflows/pipeline.yml.tpl.ts:197](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/pipeline.yml.tpl.ts#L197)
 
 Main generator that handles merging with existing workflow
 

--- a/docs/docs/api/templates/workflows/pr-title-check.yml.tpl.md
+++ b/docs/docs/api/templates/workflows/pr-title-check.yml.tpl.md
@@ -34,7 +34,7 @@ await generate({
 function generate(ctx): Promise<any>
 ```
 
-Defined in: [templates/workflows/pr-title-check.yml.tpl.ts:53](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/pr-title-check.yml.tpl.ts#L53)
+Defined in: [templates/workflows/pr-title-check.yml.tpl.ts:53](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/pr-title-check.yml.tpl.ts#L53)
 
 Generates the pr-title-check.yml workflow file.
 

--- a/docs/docs/api/templates/workflows/shared/managed-workflow.md
+++ b/docs/docs/api/templates/workflows/shared/managed-workflow.md
@@ -4,7 +4,7 @@
 
 ### ManagedWorkflowContext
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:22](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L22)
+Defined in: [templates/workflows/shared/managed-workflow.ts:22](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L22)
 
 #### Extends
 
@@ -18,7 +18,7 @@ Defined in: [templates/workflows/shared/managed-workflow.ts:22](https://github.c
 optional pinion: Configuration & object;
 ```
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:23](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L23)
+Defined in: [templates/workflows/shared/managed-workflow.ts:23](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L23)
 
 ###### Type Declaration
 
@@ -36,7 +36,7 @@ optional force: boolean;
 const MANAGED_WORKFLOW_STRINGIFY_OPTIONS: object
 ```
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:28](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L28)
+Defined in: [templates/workflows/shared/managed-workflow.ts:28](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L28)
 
 #### Type Declaration
 
@@ -78,7 +78,7 @@ minContentWidth: number = 0
 function applyManagedWorkflowOperations(doc, operations, _ctx): void
 ```
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:71](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L71)
+Defined in: [templates/workflows/shared/managed-workflow.ts:71](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L71)
 
 #### Parameters
 
@@ -106,7 +106,7 @@ Defined in: [templates/workflows/shared/managed-workflow.ts:71](https://github.c
 function createManagedWorkflowDocument(headerComment, operations, _ctx): Parsed
 ```
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:50](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L50)
+Defined in: [templates/workflows/shared/managed-workflow.ts:50](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L50)
 
 #### Parameters
 
@@ -134,7 +134,7 @@ Defined in: [templates/workflows/shared/managed-workflow.ts:50](https://github.c
 function stringifyManagedWorkflow(doc, options): string
 ```
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:79](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L79)
+Defined in: [templates/workflows/shared/managed-workflow.ts:79](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L79)
 
 #### Parameters
 
@@ -176,7 +176,7 @@ Defined in: [templates/workflows/shared/managed-workflow.ts:79](https://github.c
 function updateManagedWorkflowDocument(existingContent, operations, _ctx): Parsed
 ```
 
-Defined in: [templates/workflows/shared/managed-workflow.ts:61](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/managed-workflow.ts#L61)
+Defined in: [templates/workflows/shared/managed-workflow.ts:61](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/managed-workflow.ts#L61)
 
 #### Parameters
 

--- a/docs/docs/api/templates/workflows/shared/operations-changes.md
+++ b/docs/docs/api/templates/workflows/shared/operations-changes.md
@@ -4,7 +4,7 @@
 
 ### ChangesContext
 
-Defined in: [templates/workflows/shared/operations-changes.ts:21](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-changes.ts#L21)
+Defined in: [templates/workflows/shared/operations-changes.ts:21](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-changes.ts#L21)
 
 #### Properties
 
@@ -14,7 +14,7 @@ Defined in: [templates/workflows/shared/operations-changes.ts:21](https://github
 optional baseRef: string;
 ```
 
-Defined in: [templates/workflows/shared/operations-changes.ts:23](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-changes.ts#L23)
+Defined in: [templates/workflows/shared/operations-changes.ts:23](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-changes.ts#L23)
 
 ##### config?
 
@@ -22,7 +22,7 @@ Defined in: [templates/workflows/shared/operations-changes.ts:23](https://github
 optional config: Partial<PipecraftConfig>;
 ```
 
-Defined in: [templates/workflows/shared/operations-changes.ts:24](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-changes.ts#L24)
+Defined in: [templates/workflows/shared/operations-changes.ts:24](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-changes.ts#L24)
 
 ##### domains
 
@@ -30,7 +30,7 @@ Defined in: [templates/workflows/shared/operations-changes.ts:24](https://github
 domains: Record<string, any>
 ```
 
-Defined in: [templates/workflows/shared/operations-changes.ts:22](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-changes.ts#L22)
+Defined in: [templates/workflows/shared/operations-changes.ts:22](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-changes.ts#L22)
 
 ## Functions
 
@@ -40,7 +40,7 @@ Defined in: [templates/workflows/shared/operations-changes.ts:22](https://github
 function createChangesJobOperation(ctx): PathOperationConfig
 ```
 
-Defined in: [templates/workflows/shared/operations-changes.ts:33](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-changes.ts#L33)
+Defined in: [templates/workflows/shared/operations-changes.ts:33](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-changes.ts#L33)
 
 Create the changes detection job operation.
 

--- a/docs/docs/api/templates/workflows/shared/operations-domain-jobs.md
+++ b/docs/docs/api/templates/workflows/shared/operations-domain-jobs.md
@@ -4,7 +4,7 @@
 
 ### DomainJobsContext
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:13](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L13)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:13](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L13)
 
 #### Properties
 
@@ -14,7 +14,7 @@ Defined in: [templates/workflows/shared/operations-domain-jobs.ts:13](https://gi
 domains: Record<string, any>
 ```
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:14](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L14)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:14](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L14)
 
 ## Functions
 
@@ -24,7 +24,7 @@ Defined in: [templates/workflows/shared/operations-domain-jobs.ts:14](https://gi
 function createDomainDeployJobOperations(ctx): PathOperationConfig[]
 ```
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:134](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L134)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:134](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L134)
 
 Create deploy job operations for deployable domains
 
@@ -46,7 +46,7 @@ Create deploy job operations for deployable domains
 function createDomainRemoteTestJobOperations(ctx): PathOperationConfig[]
 ```
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:180](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L180)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:180](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L180)
 
 Create remote test job operations for remotely testable domains
 
@@ -68,7 +68,7 @@ Create remote test job operations for remotely testable domains
 function createDomainTestJobOperations(ctx): PathOperationConfig[]
 ```
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:88](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L88)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:88](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L88)
 
 Create test job operations for each domain
 
@@ -90,7 +90,7 @@ Create test job operations for each domain
 function createPrefixedDomainJobOperations(ctx): PathOperationConfig[]
 ```
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:27](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L27)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:27](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L27)
 
 Create placeholder job operations for domains with custom prefixes
 
@@ -120,7 +120,7 @@ Array of path operations for all prefix-based jobs
 function getDomainJobNames(domains): object
 ```
 
-Defined in: [templates/workflows/shared/operations-domain-jobs.ts:231](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-domain-jobs.ts#L231)
+Defined in: [templates/workflows/shared/operations-domain-jobs.ts:231](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-domain-jobs.ts#L231)
 
 Get list of all domain job names for dependency management
 

--- a/docs/docs/api/templates/workflows/shared/operations-gate.md
+++ b/docs/docs/api/templates/workflows/shared/operations-gate.md
@@ -8,7 +8,7 @@
 function ensureGateJob(doc): void
 ```
 
-Defined in: [templates/workflows/shared/operations-gate.ts:72](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-gate.ts#L72)
+Defined in: [templates/workflows/shared/operations-gate.ts:72](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-gate.ts#L72)
 
 #### Parameters
 

--- a/docs/docs/api/templates/workflows/shared/operations-header.md
+++ b/docs/docs/api/templates/workflows/shared/operations-header.md
@@ -4,7 +4,7 @@
 
 ### HeaderContext
 
-Defined in: [templates/workflows/shared/operations-header.ts:11](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L11)
+Defined in: [templates/workflows/shared/operations-header.ts:11](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L11)
 
 #### Properties
 
@@ -14,7 +14,7 @@ Defined in: [templates/workflows/shared/operations-header.ts:11](https://github.
 branchFlow: string[];
 ```
 
-Defined in: [templates/workflows/shared/operations-header.ts:12](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L12)
+Defined in: [templates/workflows/shared/operations-header.ts:12](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L12)
 
 ##### nodeVersion?
 
@@ -22,7 +22,7 @@ Defined in: [templates/workflows/shared/operations-header.ts:12](https://github.
 optional nodeVersion: string;
 ```
 
-Defined in: [templates/workflows/shared/operations-header.ts:17](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L17)
+Defined in: [templates/workflows/shared/operations-header.ts:17](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L17)
 
 Node version for the pipeline (from config.runtime, or the existing file).
 Falls back to PipeCraft defaults when not provided.
@@ -33,7 +33,7 @@ Falls back to PipeCraft defaults when not provided.
 optional nodeVersionFromConfig: boolean;
 ```
 
-Defined in: [templates/workflows/shared/operations-header.ts:28](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L28)
+Defined in: [templates/workflows/shared/operations-header.ts:28](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L28)
 
 When true, nodeVersion came from config.runtime and is authoritative:
 regeneration overwrites env.NODE_VERSION instead of preserving the existing
@@ -45,7 +45,7 @@ value. When false/undefined the existing value is preserved.
 optional pnpmVersion: string;
 ```
 
-Defined in: [templates/workflows/shared/operations-header.ts:22](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L22)
+Defined in: [templates/workflows/shared/operations-header.ts:22](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L22)
 
 pnpm version for the pipeline (from config.runtime, or the existing file).
 Falls back to PipeCraft defaults when not provided.
@@ -56,7 +56,7 @@ Falls back to PipeCraft defaults when not provided.
 optional pnpmVersionFromConfig: boolean;
 ```
 
-Defined in: [templates/workflows/shared/operations-header.ts:30](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L30)
+Defined in: [templates/workflows/shared/operations-header.ts:30](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L30)
 
 As nodeVersionFromConfig, for env.PNPM_VERSION.
 
@@ -68,7 +68,7 @@ As nodeVersionFromConfig, for env.PNPM_VERSION.
 function createHeaderOperations(ctx): PathOperationConfig[]
 ```
 
-Defined in: [templates/workflows/shared/operations-header.ts:36](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-header.ts#L36)
+Defined in: [templates/workflows/shared/operations-header.ts:36](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-header.ts#L36)
 
 Create workflow header operations (name, run-name, on triggers)
 

--- a/docs/docs/api/templates/workflows/shared/operations-tag-promote.md
+++ b/docs/docs/api/templates/workflows/shared/operations-tag-promote.md
@@ -4,7 +4,7 @@
 
 ### TagPromoteContext
 
-Defined in: [templates/workflows/shared/operations-tag-promote.ts:14](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-tag-promote.ts#L14)
+Defined in: [templates/workflows/shared/operations-tag-promote.ts:14](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-tag-promote.ts#L14)
 
 #### Properties
 
@@ -14,7 +14,7 @@ Defined in: [templates/workflows/shared/operations-tag-promote.ts:14](https://gi
 optional autoPromote: Record<string, boolean>;
 ```
 
-Defined in: [templates/workflows/shared/operations-tag-promote.ts:16](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-tag-promote.ts#L16)
+Defined in: [templates/workflows/shared/operations-tag-promote.ts:16](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-tag-promote.ts#L16)
 
 ##### branchFlow
 
@@ -22,7 +22,7 @@ Defined in: [templates/workflows/shared/operations-tag-promote.ts:16](https://gi
 branchFlow: string[];
 ```
 
-Defined in: [templates/workflows/shared/operations-tag-promote.ts:15](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-tag-promote.ts#L15)
+Defined in: [templates/workflows/shared/operations-tag-promote.ts:15](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-tag-promote.ts#L15)
 
 ##### config?
 
@@ -30,7 +30,7 @@ Defined in: [templates/workflows/shared/operations-tag-promote.ts:15](https://gi
 optional config: Partial<PipecraftConfig>;
 ```
 
-Defined in: [templates/workflows/shared/operations-tag-promote.ts:17](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-tag-promote.ts#L17)
+Defined in: [templates/workflows/shared/operations-tag-promote.ts:17](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-tag-promote.ts#L17)
 
 ## Functions
 
@@ -40,7 +40,7 @@ Defined in: [templates/workflows/shared/operations-tag-promote.ts:17](https://gi
 function createTagPromoteReleaseOperations(ctx): PathOperationConfig[]
 ```
 
-Defined in: [templates/workflows/shared/operations-tag-promote.ts:23](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-tag-promote.ts#L23)
+Defined in: [templates/workflows/shared/operations-tag-promote.ts:23](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-tag-promote.ts#L23)
 
 Create tag, promote, and release job operations
 

--- a/docs/docs/api/templates/workflows/shared/operations-version.md
+++ b/docs/docs/api/templates/workflows/shared/operations-version.md
@@ -4,7 +4,7 @@
 
 ### VersionContext
 
-Defined in: [templates/workflows/shared/operations-version.ts:14](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-version.ts#L14)
+Defined in: [templates/workflows/shared/operations-version.ts:14](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-version.ts#L14)
 
 #### Properties
 
@@ -14,7 +14,7 @@ Defined in: [templates/workflows/shared/operations-version.ts:14](https://github
 optional baseRef: string;
 ```
 
-Defined in: [templates/workflows/shared/operations-version.ts:16](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-version.ts#L16)
+Defined in: [templates/workflows/shared/operations-version.ts:16](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-version.ts#L16)
 
 ##### config?
 
@@ -22,7 +22,7 @@ Defined in: [templates/workflows/shared/operations-version.ts:16](https://github
 optional config: Partial<PipecraftConfig>;
 ```
 
-Defined in: [templates/workflows/shared/operations-version.ts:17](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-version.ts#L17)
+Defined in: [templates/workflows/shared/operations-version.ts:17](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-version.ts#L17)
 
 ##### testJobNames
 
@@ -30,7 +30,7 @@ Defined in: [templates/workflows/shared/operations-version.ts:17](https://github
 testJobNames: string[];
 ```
 
-Defined in: [templates/workflows/shared/operations-version.ts:15](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-version.ts#L15)
+Defined in: [templates/workflows/shared/operations-version.ts:15](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-version.ts#L15)
 
 ## Functions
 
@@ -40,7 +40,7 @@ Defined in: [templates/workflows/shared/operations-version.ts:15](https://github
 function createVersionJobOperation(ctx): PathOperationConfig
 ```
 
-Defined in: [templates/workflows/shared/operations-version.ts:23](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/workflows/shared/operations-version.ts#L23)
+Defined in: [templates/workflows/shared/operations-version.ts:23](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/workflows/shared/operations-version.ts#L23)
 
 Create the version calculation job operation
 

--- a/docs/docs/api/templates/yaml-format-utils.md
+++ b/docs/docs/api/templates/yaml-format-utils.md
@@ -8,7 +8,7 @@
 function formatIfConditions(yamlContent, minLength): string
 ```
 
-Defined in: [templates/yaml-format-utils.ts:24](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/templates/yaml-format-utils.ts#L24)
+Defined in: [templates/yaml-format-utils.ts:24](https://github.com/the-craftlab/pipecraft/blob/main/src/templates/yaml-format-utils.ts#L24)
 
 Formats long GitHub Actions conditional expressions for better readability.
 Takes a YAML string and formats multi-line `if:` conditions with proper indentation.

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -10,7 +10,7 @@ for generating CI/CD pipelines with trunk-based development workflows.
 
 ### DomainConfig
 
-Defined in: [types/index.ts:27](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L27)
+Defined in: [types/index.ts:27](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L27)
 
 Configuration for a single domain (monorepo workspace) in a PipeCraft project.
 
@@ -36,7 +36,7 @@ const apiDomain: DomainConfig = {
 optional deployable: boolean;
 ```
 
-Defined in: [types/index.ts:71](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L71)
+Defined in: [types/index.ts:71](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L71)
 
 Whether this domain should be deployed.
 If true, generates deployment jobs for this domain.
@@ -57,7 +57,7 @@ Use `prefixes: ['deploy']` instead for more flexibility
 description: string
 ```
 
-Defined in: [types/index.ts:38](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L38)
+Defined in: [types/index.ts:38](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L38)
 
 Human-readable description of the domain's purpose.
 Used in workflow comments and documentation.
@@ -68,7 +68,7 @@ Used in workflow comments and documentation.
 paths: string[];
 ```
 
-Defined in: [types/index.ts:32](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L32)
+Defined in: [types/index.ts:32](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L32)
 
 Glob patterns matching files in this domain.
 Changes to these paths will trigger domain-specific jobs.
@@ -79,7 +79,7 @@ Changes to these paths will trigger domain-specific jobs.
 optional prefixes: string[];
 ```
 
-Defined in: [types/index.ts:55](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L55)
+Defined in: [types/index.ts:55](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L55)
 
 Job prefixes to generate for this domain.
 Each prefix generates a customizable placeholder job named `{prefix}-{domain}`.
@@ -109,7 +109,7 @@ Prefixes provide more flexibility than the boolean flags (testable, deployable, 
 optional remoteTestable: boolean;
 ```
 
-Defined in: [types/index.ts:79](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L79)
+Defined in: [types/index.ts:79](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L79)
 
 Whether this domain should be tested remotely after deployment.
 If true, generates remote test jobs for this domain.
@@ -130,7 +130,7 @@ Use `prefixes: ['remote-test']` instead for more flexibility
 optional testable: boolean;
 ```
 
-Defined in: [types/index.ts:63](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L63)
+Defined in: [types/index.ts:63](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L63)
 
 Whether this domain has tests that should be run.
 If true, generates test jobs for this domain.
@@ -149,7 +149,7 @@ Use `prefixes: ['test']` instead for more flexibility
 
 ### PipecraftConfig
 
-Defined in: [types/index.ts:113](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L113)
+Defined in: [types/index.ts:113](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L113)
 
 Complete PipeCraft configuration schema.
 
@@ -190,7 +190,7 @@ const config: PipecraftConfig = {
 optional actionSourceMode: "local" | "remote" | "source";
 ```
 
-Defined in: [types/index.ts:276](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L276)
+Defined in: [types/index.ts:276](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L276)
 
 How workflows should reference PipeCraft actions.
 
@@ -227,7 +227,7 @@ actionSourceMode: 'source'
 optional actionVersion: string;
 ```
 
-Defined in: [types/index.ts:285](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L285)
+Defined in: [types/index.ts:285](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L285)
 
 Version/tag to use when actionSourceMode is 'remote'.
 Pins workflows to a specific marketplace action version.
@@ -250,7 +250,7 @@ Pins workflows to a specific marketplace action version.
 optional autoPromote: boolean | Record<string, boolean>;
 ```
 
-Defined in: [types/index.ts:164](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L164)
+Defined in: [types/index.ts:164](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L164)
 
 Auto-promote configuration for branch promotions.
 
@@ -273,7 +273,7 @@ false
 branchFlow: string[];
 ```
 
-Defined in: [types/index.ts:152](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L152)
+Defined in: [types/index.ts:152](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L152)
 
 Ordered list of branches in the promotion flow from initial to final.
 Must start with initialBranch and end with finalBranch.
@@ -290,7 +290,7 @@ Must start with initialBranch and end with finalBranch.
 ciProvider: 'github' | 'gitlab'
 ```
 
-Defined in: [types/index.ts:118](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L118)
+Defined in: [types/index.ts:118](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L118)
 
 CI/CD provider platform.
 Currently 'github' is fully supported, 'gitlab' support is planned.
@@ -301,7 +301,7 @@ Currently 'github' is fully supported, 'gitlab' support is planned.
 domains: Record<string, DomainConfig>
 ```
 
-Defined in: [types/index.ts:210](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L210)
+Defined in: [types/index.ts:210](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L210)
 
 Domain definitions for monorepo path-based change detection.
 Each domain represents a logical part of the codebase with its own
@@ -313,7 +313,7 @@ test and deployment requirements.
 finalBranch: string
 ```
 
-Defined in: [types/index.ts:144](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L144)
+Defined in: [types/index.ts:144](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L144)
 
 The final production branch (typically 'main' or 'master').
 This is the last branch in the promotion flow.
@@ -324,7 +324,7 @@ This is the last branch in the promotion flow.
 initialBranch: string
 ```
 
-Defined in: [types/index.ts:138](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L138)
+Defined in: [types/index.ts:138](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L138)
 
 The first branch in the promotion flow (typically 'develop' or 'dev').
 All feature branches merge into this branch.
@@ -340,7 +340,7 @@ optional mergeMethod:
 | Record<string, "merge" | "auto" | "squash" | "rebase">;
 ```
 
-Defined in: [types/index.ts:176](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L176)
+Defined in: [types/index.ts:176](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L176)
 
 Git merge method for auto-merge operations.
 
@@ -363,7 +363,7 @@ Can be set globally or per-branch.
 mergeStrategy: 'fast-forward' | 'merge'
 ```
 
-Defined in: [types/index.ts:125](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L125)
+Defined in: [types/index.ts:125](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L125)
 
 Git merge strategy for branch promotions.
 
@@ -376,7 +376,7 @@ Git merge strategy for branch promotions.
 optional packageManager: "npm" | "yarn" | "pnpm";
 ```
 
-Defined in: [types/index.ts:220](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L220)
+Defined in: [types/index.ts:220](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L220)
 
 Package manager used for dependency installation.
 
@@ -393,7 +393,7 @@ configs with this field will continue to work, but it has no effect.
 optional rebuild: object;
 ```
 
-Defined in: [types/index.ts:291](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L291)
+Defined in: [types/index.ts:291](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L291)
 
 Idempotency and rebuild configuration.
 Controls when workflows should be regenerated based on config/template changes.
@@ -462,7 +462,7 @@ Enable watch mode for automatic regeneration on config changes.
 requireConventionalCommits: boolean
 ```
 
-Defined in: [types/index.ts:132](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L132)
+Defined in: [types/index.ts:132](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L132)
 
 Whether to enforce conventional commit message format.
 If true, commit messages must follow the Conventional Commits specification.
@@ -477,7 +477,7 @@ https://www.conventionalcommits.org/
 optional runtime: object;
 ```
 
-Defined in: [types/index.ts:236](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L236)
+Defined in: [types/index.ts:236](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L236)
 
 Runtime tool versions for generated CI/CD workflows.
 
@@ -529,7 +529,7 @@ runtime: { nodeVersion: '22', pnpmVersion: '10' }
 semver: object
 ```
 
-Defined in: [types/index.ts:198](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L198)
+Defined in: [types/index.ts:198](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L198)
 
 Semantic versioning configuration.
 Maps conventional commit types to version bump levels.
@@ -560,7 +560,7 @@ semver: {
 optional versioning: object;
 ```
 
-Defined in: [types/index.ts:334](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/types/index.ts#L334)
+Defined in: [types/index.ts:334](https://github.com/the-craftlab/pipecraft/blob/main/src/types/index.ts#L334)
 
 Version management configuration using release-it.
 Enables automatic version bumping, tagging, and changelog generation.

--- a/docs/docs/api/utils/action-reference.md
+++ b/docs/docs/api/utils/action-reference.md
@@ -13,7 +13,7 @@ the configured action source mode (embedded, marketplace, or repository).
 function getActionOutputDir(config): string
 ```
 
-Defined in: [utils/action-reference.ts:76](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/action-reference.ts#L76)
+Defined in: [utils/action-reference.ts:76](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/action-reference.ts#L76)
 
 Get the output directory for action files during generation.
 
@@ -49,7 +49,7 @@ getActionOutputDir({ actionSourceMode: 'source' })
 function getActionReference(actionName, config): string
 ```
 
-Defined in: [utils/action-reference.ts:37](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/action-reference.ts#L37)
+Defined in: [utils/action-reference.ts:37](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/action-reference.ts#L37)
 
 Generate the action reference path based on configuration.
 
@@ -100,7 +100,7 @@ getActionReference('detect-changes', { actionSourceMode: 'source' })
 function getActionSourceDescription(config): string
 ```
 
-Defined in: [utils/action-reference.ts:119](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/action-reference.ts#L119)
+Defined in: [utils/action-reference.ts:119](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/action-reference.ts#L119)
 
 Get human-readable description of the action source mode.
 
@@ -126,7 +126,7 @@ Description string for logging/display
 function shouldGenerateActions(config): boolean
 ```
 
-Defined in: [utils/action-reference.ts:108](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/action-reference.ts#L108)
+Defined in: [utils/action-reference.ts:108](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/action-reference.ts#L108)
 
 Check if actions should be generated locally.
 

--- a/docs/docs/api/utils/ast-path-operations.md
+++ b/docs/docs/api/utils/ast-path-operations.md
@@ -4,7 +4,7 @@
 
 ### PathOperationConfig
 
-Defined in: [utils/ast-path-operations.ts:127](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L127)
+Defined in: [utils/ast-path-operations.ts:127](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L127)
 
 Configuration for a single path operation
 
@@ -33,7 +33,7 @@ const config: PathOperationConfig = {
 optional comment: string;
 ```
 
-Defined in: [utils/ast-path-operations.ts:133](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L133)
+Defined in: [utils/ast-path-operations.ts:133](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L133)
 
 ##### commentBefore?
 
@@ -41,7 +41,7 @@ Defined in: [utils/ast-path-operations.ts:133](https://github.com/the-craftlab/p
 optional commentBefore: string;
 ```
 
-Defined in: [utils/ast-path-operations.ts:132](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L132)
+Defined in: [utils/ast-path-operations.ts:132](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L132)
 
 ##### operation
 
@@ -49,7 +49,7 @@ Defined in: [utils/ast-path-operations.ts:132](https://github.com/the-craftlab/p
 operation: PathOperation
 ```
 
-Defined in: [utils/ast-path-operations.ts:129](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L129)
+Defined in: [utils/ast-path-operations.ts:129](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L129)
 
 Type of operation to perform
 
@@ -59,7 +59,7 @@ Type of operation to perform
 path: string
 ```
 
-Defined in: [utils/ast-path-operations.ts:128](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L128)
+Defined in: [utils/ast-path-operations.ts:128](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L128)
 
 Dot-notation path to target (e.g., 'jobs.changes.steps')
 
@@ -69,7 +69,7 @@ Dot-notation path to target (e.g., 'jobs.changes.steps')
 optional required: boolean;
 ```
 
-Defined in: [utils/ast-path-operations.ts:131](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L131)
+Defined in: [utils/ast-path-operations.ts:131](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L131)
 
 Whether the path must exist
 
@@ -79,7 +79,7 @@ Whether the path must exist
 optional spaceBefore: boolean;
 ```
 
-Defined in: [utils/ast-path-operations.ts:134](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L134)
+Defined in: [utils/ast-path-operations.ts:134](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L134)
 
 ##### spaceBeforeComment?
 
@@ -87,7 +87,7 @@ Defined in: [utils/ast-path-operations.ts:134](https://github.com/the-craftlab/p
 optional spaceBeforeComment: boolean;
 ```
 
-Defined in: [utils/ast-path-operations.ts:135](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L135)
+Defined in: [utils/ast-path-operations.ts:135](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L135)
 
 ##### tag?
 
@@ -95,7 +95,7 @@ Defined in: [utils/ast-path-operations.ts:135](https://github.com/the-craftlab/p
 optional tag: string;
 ```
 
-Defined in: [utils/ast-path-operations.ts:136](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L136)
+Defined in: [utils/ast-path-operations.ts:136](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L136)
 
 ##### value
 
@@ -103,7 +103,7 @@ Defined in: [utils/ast-path-operations.ts:136](https://github.com/the-craftlab/p
 value: PathValue
 ```
 
-Defined in: [utils/ast-path-operations.ts:130](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L130)
+Defined in: [utils/ast-path-operations.ts:130](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L130)
 
 Value to set/merge/overwrite
 
@@ -115,7 +115,7 @@ Value to set/merge/overwrite
 type PathOperation = 'set' | 'merge' | 'overwrite' | 'preserve'
 ```
 
-Defined in: [utils/ast-path-operations.ts:93](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L93)
+Defined in: [utils/ast-path-operations.ts:93](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L93)
 
 Available operation types for path-based AST manipulation
 
@@ -127,7 +127,7 @@ Available operation types for path-based AST manipulation
 type PathValue = Node | object | string | number | boolean | any[]
 ```
 
-Defined in: [utils/ast-path-operations.ts:102](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L102)
+Defined in: [utils/ast-path-operations.ts:102](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L102)
 
 Supported value types for path operations
 
@@ -139,7 +139,7 @@ Supported value types for path operations
 function applyPathOperations(doc, operations, document?): void
 ```
 
-Defined in: [utils/ast-path-operations.ts:503](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L503)
+Defined in: [utils/ast-path-operations.ts:503](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L503)
 
 Apply multiple path operations to a document
 
@@ -199,7 +199,7 @@ applyPathOperations(doc, operations)
 function createValueFromArray(arr): Node
 ```
 
-Defined in: [utils/ast-path-operations.ts:645](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L645)
+Defined in: [utils/ast-path-operations.ts:645](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L645)
 
 Create a YAML node from a JavaScript array
 
@@ -233,7 +233,7 @@ const node = createValueFromArray(['develop', 'staging', 'main'])
 function createValueFromObject(obj, doc?): Node
 ```
 
-Defined in: [utils/ast-path-operations.ts:625](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L625)
+Defined in: [utils/ast-path-operations.ts:625](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L625)
 
 Create a YAML node from a JavaScript object
 
@@ -275,7 +275,7 @@ const node = createValueFromObject({
 function createValueFromString(yamlString, context?, document?): Node
 ```
 
-Defined in: [utils/ast-path-operations.ts:541](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L541)
+Defined in: [utils/ast-path-operations.ts:541](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L541)
 
 Create a YAML node from a YAML string
 
@@ -325,7 +325,7 @@ const node = createValueFromString(`
 function ensurePathAndApply(doc, config, document?): void
 ```
 
-Defined in: [utils/ast-path-operations.ts:303](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L303)
+Defined in: [utils/ast-path-operations.ts:303](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L303)
 
 Ensure a path exists and apply the specified operation
 
@@ -376,7 +376,7 @@ ensurePathAndApply(doc, config)
 function getPathValue(doc, path): Node | null
 ```
 
-Defined in: [utils/ast-path-operations.ts:265](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L265)
+Defined in: [utils/ast-path-operations.ts:265](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L265)
 
 Get a value at a specific path in the YAML AST
 
@@ -419,7 +419,7 @@ console.log(value) // Scalar('ubuntu-latest')
 function setPathValue(doc, path, value, document?, commentBefore?, spaceBeforeComment?): void
 ```
 
-Defined in: [utils/ast-path-operations.ts:158](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/ast-path-operations.ts#L158)
+Defined in: [utils/ast-path-operations.ts:158](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/ast-path-operations.ts#L158)
 
 Set a value at a specific path in the YAML AST
 

--- a/docs/docs/api/utils/config.md
+++ b/docs/docs/api/utils/config.md
@@ -24,7 +24,7 @@ and have valid values before being used to generate workflows.
 const RESERVED_JOB_NAMES: readonly ['version', 'changes', 'gate', 'tag', 'promote', 'release']
 ```
 
-Defined in: [utils/config.ts:27](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/config.ts#L27)
+Defined in: [utils/config.ts:27](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/config.ts#L27)
 
 Reserved job names that cannot be used as domain names.
 These are managed by Pipecraft and would conflict with generated workflow jobs.
@@ -37,7 +37,7 @@ These are managed by Pipecraft and would conflict with generated workflow jobs.
 function loadConfig(configPath?): any
 ```
 
-Defined in: [utils/config.ts:63](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/config.ts#L63)
+Defined in: [utils/config.ts:63](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/config.ts#L63)
 
 Load PipeCraft configuration from filesystem.
 
@@ -89,7 +89,7 @@ const config = loadConfig('./my-config.json')
 function validateConfig(config): boolean
 ```
 
-Defined in: [utils/config.ts:113](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/config.ts#L113)
+Defined in: [utils/config.ts:113](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/config.ts#L113)
 
 Validate PipeCraft configuration structure and values.
 

--- a/docs/docs/api/utils/doctor.md
+++ b/docs/docs/api/utils/doctor.md
@@ -15,7 +15,7 @@ Performs comprehensive health checks on a Pipecraft setup:
 
 ### CheckCategory
 
-Defined in: [utils/doctor.ts:74](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L74)
+Defined in: [utils/doctor.ts:74](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L74)
 
 #### Properties
 
@@ -25,7 +25,7 @@ Defined in: [utils/doctor.ts:74](https://github.com/the-craftlab/pipecraft/blob/
 name: string
 ```
 
-Defined in: [utils/doctor.ts:75](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L75)
+Defined in: [utils/doctor.ts:75](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L75)
 
 ##### results
 
@@ -33,13 +33,13 @@ Defined in: [utils/doctor.ts:75](https://github.com/the-craftlab/pipecraft/blob/
 results: CheckResult[];
 ```
 
-Defined in: [utils/doctor.ts:76](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L76)
+Defined in: [utils/doctor.ts:76](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L76)
 
 ---
 
 ### CheckResult
 
-Defined in: [utils/doctor.ts:65](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L65)
+Defined in: [utils/doctor.ts:65](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L65)
 
 #### Properties
 
@@ -49,7 +49,7 @@ Defined in: [utils/doctor.ts:65](https://github.com/the-craftlab/pipecraft/blob/
 optional fix: object;
 ```
 
-Defined in: [utils/doctor.ts:68](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L68)
+Defined in: [utils/doctor.ts:68](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L68)
 
 ###### command?
 
@@ -69,7 +69,7 @@ description: string
 message: string
 ```
 
-Defined in: [utils/doctor.ts:67](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L67)
+Defined in: [utils/doctor.ts:67](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L67)
 
 ##### status
 
@@ -77,13 +77,13 @@ Defined in: [utils/doctor.ts:67](https://github.com/the-craftlab/pipecraft/blob/
 status: CheckStatus
 ```
 
-Defined in: [utils/doctor.ts:66](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L66)
+Defined in: [utils/doctor.ts:66](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L66)
 
 ---
 
 ### DoctorResult
 
-Defined in: [utils/doctor.ts:79](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L79)
+Defined in: [utils/doctor.ts:79](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L79)
 
 #### Properties
 
@@ -93,7 +93,7 @@ Defined in: [utils/doctor.ts:79](https://github.com/the-craftlab/pipecraft/blob/
 categories: CheckCategory[];
 ```
 
-Defined in: [utils/doctor.ts:80](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L80)
+Defined in: [utils/doctor.ts:80](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L80)
 
 ##### errorCount
 
@@ -101,7 +101,7 @@ Defined in: [utils/doctor.ts:80](https://github.com/the-craftlab/pipecraft/blob/
 errorCount: number
 ```
 
-Defined in: [utils/doctor.ts:81](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L81)
+Defined in: [utils/doctor.ts:81](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L81)
 
 ##### warningCount
 
@@ -109,7 +109,7 @@ Defined in: [utils/doctor.ts:81](https://github.com/the-craftlab/pipecraft/blob/
 warningCount: number
 ```
 
-Defined in: [utils/doctor.ts:82](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L82)
+Defined in: [utils/doctor.ts:82](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L82)
 
 ## Type Aliases
 
@@ -119,7 +119,7 @@ Defined in: [utils/doctor.ts:82](https://github.com/the-craftlab/pipecraft/blob/
 type CheckStatus = 'success' | 'error' | 'warning'
 ```
 
-Defined in: [utils/doctor.ts:63](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L63)
+Defined in: [utils/doctor.ts:63](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L63)
 
 ## Functions
 
@@ -129,7 +129,7 @@ Defined in: [utils/doctor.ts:63](https://github.com/the-craftlab/pipecraft/blob/
 function checkBranches(): CheckCategory
 ```
 
-Defined in: [utils/doctor.ts:347](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L347)
+Defined in: [utils/doctor.ts:347](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L347)
 
 Check 3: Branches exist on remote
 
@@ -145,7 +145,7 @@ Check 3: Branches exist on remote
 function checkConfiguration(): CheckCategory
 ```
 
-Defined in: [utils/doctor.ts:191](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L191)
+Defined in: [utils/doctor.ts:191](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L191)
 
 Check 1: Configuration validation
 
@@ -161,7 +161,7 @@ Check 1: Configuration validation
 function checkDomainPaths(): Promise<CheckCategory>
 ```
 
-Defined in: [utils/doctor.ts:629](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L629)
+Defined in: [utils/doctor.ts:629](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L629)
 
 Check 6: Domain paths match files
 
@@ -177,7 +177,7 @@ Check 6: Domain paths match files
 function checkGeneratedFiles(): CheckCategory
 ```
 
-Defined in: [utils/doctor.ts:419](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L419)
+Defined in: [utils/doctor.ts:419](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L419)
 
 Check 4: Required actions exist
 
@@ -193,7 +193,7 @@ Check 4: Required actions exist
 function checkGitHubPermissions(): Promise<CheckCategory>
 ```
 
-Defined in: [utils/doctor.ts:237](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L237)
+Defined in: [utils/doctor.ts:237](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L237)
 
 Check 2: GitHub workflow permissions
 
@@ -209,7 +209,7 @@ Check 2: GitHub workflow permissions
 function checkWorkflowSemantics(): CheckCategory
 ```
 
-Defined in: [utils/doctor.ts:557](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L557)
+Defined in: [utils/doctor.ts:557](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L557)
 
 Check 5: Workflow semantic validation
 
@@ -225,7 +225,7 @@ Check 5: Workflow semantic validation
 function formatDoctorOutput(result): string
 ```
 
-Defined in: [utils/doctor.ts:121](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L121)
+Defined in: [utils/doctor.ts:121](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L121)
 
 #### Parameters
 
@@ -245,7 +245,7 @@ Defined in: [utils/doctor.ts:121](https://github.com/the-craftlab/pipecraft/blob
 function runDoctor(): Promise<DoctorResult>
 ```
 
-Defined in: [utils/doctor.ts:701](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/doctor.ts#L701)
+Defined in: [utils/doctor.ts:701](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/doctor.ts#L701)
 
 Run all diagnostic checks and return the results.
 

--- a/docs/docs/api/utils/github-setup.md
+++ b/docs/docs/api/utils/github-setup.md
@@ -59,7 +59,7 @@ Result: develop requires manual review, staging and main auto-merge when checks 
 function configureBranchProtection(repoInfo, token, autoApply): Promise<void>
 ```
 
-Defined in: [utils/github-setup.ts:1171](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L1171)
+Defined in: [utils/github-setup.ts:1171](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L1171)
 
 Configure branch protection for branches that need auto-merge
 
@@ -89,7 +89,7 @@ Configure branch protection for branches that need auto-merge
 function displaySettingsComparison(current, recommended, gaps): void
 ```
 
-Defined in: [utils/github-setup.ts:933](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L933)
+Defined in: [utils/github-setup.ts:933](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L933)
 
 Display a comparison table of current vs recommended settings.
 
@@ -119,7 +119,7 @@ Display a comparison table of current vs recommended settings.
 function enableAutoMerge(owner, repo, token): Promise<boolean>
 ```
 
-Defined in: [utils/github-setup.ts:1125](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L1125)
+Defined in: [utils/github-setup.ts:1125](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L1125)
 
 Enable auto-merge feature for the repository
 
@@ -149,7 +149,7 @@ Enable auto-merge feature for the repository
 function formatOrgActionsLockMessage(owner, apiError?): string
 ```
 
-Defined in: [utils/github-setup.ts:404](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L404)
+Defined in: [utils/github-setup.ts:404](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L404)
 
 Build an actionable, human-readable message explaining that an organization
 policy is blocking the repository's workflow permissions, and exactly how an
@@ -184,7 +184,7 @@ A multi-line actionable message
 function getBranchProtection(owner, repo, branch, token): Promise<BranchProtectionRules | null>
 ```
 
-Defined in: [utils/github-setup.ts:1047](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L1047)
+Defined in: [utils/github-setup.ts:1047](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L1047)
 
 Get branch protection rules
 
@@ -218,7 +218,7 @@ Get branch protection rules
 function getGitHubToken(): string
 ```
 
-Defined in: [utils/github-setup.ts:291](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L291)
+Defined in: [utils/github-setup.ts:291](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L291)
 
 Get GitHub authentication token from environment or GitHub CLI.
 
@@ -262,7 +262,7 @@ const token = getGitHubToken() // Uses gh CLI token
 function getMergeCommitSettings(owner, repo, token): Promise<RepositorySettings>
 ```
 
-Defined in: [utils/github-setup.ts:571](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L571)
+Defined in: [utils/github-setup.ts:571](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L571)
 
 Get current merge commit message settings for the repository.
 
@@ -314,7 +314,7 @@ console.log(settings.squash_merge_commit_title) // 'PR_TITLE' or 'COMMIT_OR_PR_T
 function getOrgWorkflowPermissions(org, token): Promise<WorkflowPermissions | null>
 ```
 
-Defined in: [utils/github-setup.ts:432](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L432)
+Defined in: [utils/github-setup.ts:432](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L432)
 
 Get organization-level workflow permissions.
 
@@ -352,7 +352,7 @@ The org workflow permissions, or null if not determinable
 function getRecommendedRepositorySettings(): RepositorySettings
 ```
 
-Defined in: [utils/github-setup.ts:817](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L817)
+Defined in: [utils/github-setup.ts:817](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L817)
 
 Get Pipecraft's recommended repository settings.
 
@@ -378,7 +378,7 @@ These are the settings that work best with Pipecraft workflows:
 function getRepositoryInfo(): RepositoryInfo
 ```
 
-Defined in: [utils/github-setup.ts:238](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L238)
+Defined in: [utils/github-setup.ts:238](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L238)
 
 Extract GitHub repository information from git remote configuration.
 
@@ -421,7 +421,7 @@ console.log(`Owner: ${info.owner}, Repo: ${info.repo}`)
 function getRepositorySettings(owner, repo, token): Promise<RepositorySettings>
 ```
 
-Defined in: [utils/github-setup.ts:832](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L832)
+Defined in: [utils/github-setup.ts:832](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L832)
 
 Get current repository settings from GitHub API.
 
@@ -451,7 +451,7 @@ Get current repository settings from GitHub API.
 function getRequiredMergeCommitChanges(currentSettings): RepositorySettings | null
 ```
 
-Defined in: [utils/github-setup.ts:665](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L665)
+Defined in: [utils/github-setup.ts:665](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L665)
 
 Determine required merge commit setting changes without prompting.
 
@@ -493,7 +493,7 @@ if (changes) {
 function getRequiredPermissionChanges(currentPermissions): Partial<WorkflowPermissions> | null
 ```
 
-Defined in: [utils/github-setup.ts:456](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L456)
+Defined in: [utils/github-setup.ts:456](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L456)
 
 Determine required permission changes without prompting
 Returns: changes object if changes needed, null if already correct
@@ -516,7 +516,7 @@ Returns: changes object if changes needed, null if already correct
 function getSettingsGaps(current, recommended): Partial<RepositorySettings>
 ```
 
-Defined in: [utils/github-setup.ts:893](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L893)
+Defined in: [utils/github-setup.ts:893](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L893)
 
 Compare current settings with recommended settings and return differences.
 
@@ -542,7 +542,7 @@ Compare current settings with recommended settings and return differences.
 function getWorkflowPermissions(owner, repo, token): Promise<WorkflowPermissions>
 ```
 
-Defined in: [utils/github-setup.ts:319](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L319)
+Defined in: [utils/github-setup.ts:319](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L319)
 
 Get current workflow permissions
 
@@ -572,7 +572,7 @@ Get current workflow permissions
 function isOrgActionsPermissionLock(status): boolean
 ```
 
-Defined in: [utils/github-setup.ts:390](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L390)
+Defined in: [utils/github-setup.ts:390](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L390)
 
 Whether an HTTP status from the Actions workflow-permissions API indicates an
 organization-level policy lock.
@@ -604,7 +604,7 @@ true if the status is the org-policy conflict (409)
 function promptApplySettings(gaps): Promise<'declined' | 'apply'>
 ```
 
-Defined in: [utils/github-setup.ts:1025](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L1025)
+Defined in: [utils/github-setup.ts:1025](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L1025)
 
 Prompt user whether to apply recommended settings.
 
@@ -626,7 +626,7 @@ Prompt user whether to apply recommended settings.
 function promptMergeCommitChanges(currentSettings): Promise<RepositorySettings | 'declined' | null>
 ```
 
-Defined in: [utils/github-setup.ts:707](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L707)
+Defined in: [utils/github-setup.ts:707](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L707)
 
 Display current merge commit settings and prompt for changes.
 
@@ -668,7 +668,7 @@ function promptPermissionChanges(
 ): Promise<Partial<WorkflowPermissions> | 'declined' | null>
 ```
 
-Defined in: [utils/github-setup.ts:484](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L484)
+Defined in: [utils/github-setup.ts:484](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L484)
 
 Display current permissions and prompt for changes
 Returns: changes object if user accepted changes, 'declined' if user declined, null if already correct
@@ -691,7 +691,7 @@ Returns: changes object if user accepted changes, 'declined' if user declined, n
 function setupGitHubPermissions(autoApply): Promise<void>
 ```
 
-Defined in: [utils/github-setup.ts:1261](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L1261)
+Defined in: [utils/github-setup.ts:1261](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L1261)
 
 Main setup function
 
@@ -713,7 +713,7 @@ Main setup function
 function shouldEnableAutoMerge(): boolean
 ```
 
-Defined in: [utils/github-setup.ts:781](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L781)
+Defined in: [utils/github-setup.ts:781](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L781)
 
 Check if auto-merge should be enabled based on .pipecraftrc config.
 
@@ -732,7 +732,7 @@ has autoPromote configured in the config file.
 function updateBranchProtection(owner, repo, branch, token): Promise<void>
 ```
 
-Defined in: [utils/github-setup.ts:1080](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L1080)
+Defined in: [utils/github-setup.ts:1080](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L1080)
 
 Update branch protection rules to enable auto-merge
 
@@ -766,7 +766,7 @@ Update branch protection rules to enable auto-merge
 function updateMergeCommitSettings(owner, repo, token, settings): Promise<void>
 ```
 
-Defined in: [utils/github-setup.ts:622](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L622)
+Defined in: [utils/github-setup.ts:622](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L622)
 
 Update merge commit message settings for the repository.
 
@@ -825,7 +825,7 @@ await updateMergeCommitSettings('owner', 'repo', token, {
 function updateRepositorySettings(owner, repo, token, settings): Promise<void>
 ```
 
-Defined in: [utils/github-setup.ts:867](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L867)
+Defined in: [utils/github-setup.ts:867](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L867)
 
 Update repository settings via GitHub API.
 
@@ -859,7 +859,7 @@ Update repository settings via GitHub API.
 function updateWorkflowPermissions(owner, repo, token, permissions): Promise<void>
 ```
 
-Defined in: [utils/github-setup.ts:346](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/github-setup.ts#L346)
+Defined in: [utils/github-setup.ts:346](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/github-setup.ts#L346)
 
 Update workflow permissions
 

--- a/docs/docs/api/utils/logger.md
+++ b/docs/docs/api/utils/logger.md
@@ -23,7 +23,7 @@ passed to the CLI commands.
 type LogLevel = 'silent' | 'normal' | 'verbose' | 'debug'
 ```
 
-Defined in: [utils/logger.ts:26](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/logger.ts#L26)
+Defined in: [utils/logger.ts:26](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/logger.ts#L26)
 
 Available log verbosity levels in ascending order of detail.
 
@@ -40,7 +40,7 @@ Available log verbosity levels in ascending order of detail.
 const logger: Logger
 ```
 
-Defined in: [utils/logger.ts:171](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/logger.ts#L171)
+Defined in: [utils/logger.ts:171](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/logger.ts#L171)
 
 Singleton logger instance exported for use throughout the application.
 

--- a/docs/docs/api/utils/messaging.md
+++ b/docs/docs/api/utils/messaging.md
@@ -36,7 +36,7 @@ and provides clear, actionable feedback during GitHub setup.
 
 ### MessageContext
 
-Defined in: [utils/messaging.ts:38](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L38)
+Defined in: [utils/messaging.ts:38](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L38)
 
 #### Properties
 
@@ -46,7 +46,7 @@ Defined in: [utils/messaging.ts:38](https://github.com/the-craftlab/pipecraft/bl
 autoApply: boolean
 ```
 
-Defined in: [utils/messaging.ts:41](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L41)
+Defined in: [utils/messaging.ts:41](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L41)
 
 ##### persona
 
@@ -54,7 +54,7 @@ Defined in: [utils/messaging.ts:41](https://github.com/the-craftlab/pipecraft/bl
 persona: UserPersona
 ```
 
-Defined in: [utils/messaging.ts:39](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L39)
+Defined in: [utils/messaging.ts:39](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L39)
 
 ##### verbose
 
@@ -62,13 +62,13 @@ Defined in: [utils/messaging.ts:39](https://github.com/the-craftlab/pipecraft/bl
 verbose: boolean
 ```
 
-Defined in: [utils/messaging.ts:40](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L40)
+Defined in: [utils/messaging.ts:40](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L40)
 
 ---
 
 ### SetupSummary
 
-Defined in: [utils/messaging.ts:54](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L54)
+Defined in: [utils/messaging.ts:54](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L54)
 
 #### Properties
 
@@ -78,7 +78,7 @@ Defined in: [utils/messaging.ts:54](https://github.com/the-craftlab/pipecraft/bl
 autoPromote: StatusItem[];
 ```
 
-Defined in: [utils/messaging.ts:59](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L59)
+Defined in: [utils/messaging.ts:59](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L59)
 
 ##### errors
 
@@ -86,7 +86,7 @@ Defined in: [utils/messaging.ts:59](https://github.com/the-craftlab/pipecraft/bl
 errors: string[];
 ```
 
-Defined in: [utils/messaging.ts:62](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L62)
+Defined in: [utils/messaging.ts:62](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L62)
 
 ##### nextSteps
 
@@ -94,7 +94,7 @@ Defined in: [utils/messaging.ts:62](https://github.com/the-craftlab/pipecraft/bl
 nextSteps: string[];
 ```
 
-Defined in: [utils/messaging.ts:60](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L60)
+Defined in: [utils/messaging.ts:60](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L60)
 
 ##### overallStatus
 
@@ -102,7 +102,7 @@ Defined in: [utils/messaging.ts:60](https://github.com/the-craftlab/pipecraft/bl
 overallStatus: 'error' | 'ready' | 'needs-setup' | 'partial'
 ```
 
-Defined in: [utils/messaging.ts:56](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L56)
+Defined in: [utils/messaging.ts:56](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L56)
 
 ##### permissions
 
@@ -110,7 +110,7 @@ Defined in: [utils/messaging.ts:56](https://github.com/the-craftlab/pipecraft/bl
 permissions: StatusItem[];
 ```
 
-Defined in: [utils/messaging.ts:57](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L57)
+Defined in: [utils/messaging.ts:57](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L57)
 
 ##### repository
 
@@ -118,7 +118,7 @@ Defined in: [utils/messaging.ts:57](https://github.com/the-craftlab/pipecraft/bl
 repository: string
 ```
 
-Defined in: [utils/messaging.ts:55](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L55)
+Defined in: [utils/messaging.ts:55](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L55)
 
 ##### settings
 
@@ -126,7 +126,7 @@ Defined in: [utils/messaging.ts:55](https://github.com/the-craftlab/pipecraft/bl
 settings: StatusItem[];
 ```
 
-Defined in: [utils/messaging.ts:58](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L58)
+Defined in: [utils/messaging.ts:58](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L58)
 
 ##### warnings
 
@@ -134,13 +134,13 @@ Defined in: [utils/messaging.ts:58](https://github.com/the-craftlab/pipecraft/bl
 warnings: string[];
 ```
 
-Defined in: [utils/messaging.ts:61](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L61)
+Defined in: [utils/messaging.ts:61](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L61)
 
 ---
 
 ### StatusItem
 
-Defined in: [utils/messaging.ts:44](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L44)
+Defined in: [utils/messaging.ts:44](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L44)
 
 #### Properties
 
@@ -150,7 +150,7 @@ Defined in: [utils/messaging.ts:44](https://github.com/the-craftlab/pipecraft/bl
 optional action: string;
 ```
 
-Defined in: [utils/messaging.ts:51](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L51)
+Defined in: [utils/messaging.ts:51](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L51)
 
 ##### category
 
@@ -158,7 +158,7 @@ Defined in: [utils/messaging.ts:51](https://github.com/the-craftlab/pipecraft/bl
 category: string
 ```
 
-Defined in: [utils/messaging.ts:45](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L45)
+Defined in: [utils/messaging.ts:45](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L45)
 
 ##### current
 
@@ -166,7 +166,7 @@ Defined in: [utils/messaging.ts:45](https://github.com/the-craftlab/pipecraft/bl
 current: string
 ```
 
-Defined in: [utils/messaging.ts:47](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L47)
+Defined in: [utils/messaging.ts:47](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L47)
 
 ##### explanation?
 
@@ -174,7 +174,7 @@ Defined in: [utils/messaging.ts:47](https://github.com/the-craftlab/pipecraft/bl
 optional explanation: string;
 ```
 
-Defined in: [utils/messaging.ts:50](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L50)
+Defined in: [utils/messaging.ts:50](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L50)
 
 ##### name
 
@@ -182,7 +182,7 @@ Defined in: [utils/messaging.ts:50](https://github.com/the-craftlab/pipecraft/bl
 name: string
 ```
 
-Defined in: [utils/messaging.ts:46](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L46)
+Defined in: [utils/messaging.ts:46](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L46)
 
 ##### recommended
 
@@ -190,7 +190,7 @@ Defined in: [utils/messaging.ts:46](https://github.com/the-craftlab/pipecraft/bl
 recommended: string | null
 ```
 
-Defined in: [utils/messaging.ts:48](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L48)
+Defined in: [utils/messaging.ts:48](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L48)
 
 ##### status
 
@@ -198,7 +198,7 @@ Defined in: [utils/messaging.ts:48](https://github.com/the-craftlab/pipecraft/bl
 status: 'error' | 'correct' | 'needs-change' | 'missing'
 ```
 
-Defined in: [utils/messaging.ts:49](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L49)
+Defined in: [utils/messaging.ts:49](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L49)
 
 ## Type Aliases
 
@@ -208,7 +208,7 @@ Defined in: [utils/messaging.ts:49](https://github.com/the-craftlab/pipecraft/bl
 type MessageSeverity = 'critical' | 'warning' | 'info' | 'success'
 ```
 
-Defined in: [utils/messaging.ts:36](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L36)
+Defined in: [utils/messaging.ts:36](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L36)
 
 ---
 
@@ -218,7 +218,7 @@ Defined in: [utils/messaging.ts:36](https://github.com/the-craftlab/pipecraft/bl
 type UserPersona = 'startup' | 'team-lead' | 'platform-engineer'
 ```
 
-Defined in: [utils/messaging.ts:34](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L34)
+Defined in: [utils/messaging.ts:34](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L34)
 
 ## Functions
 
@@ -228,7 +228,7 @@ Defined in: [utils/messaging.ts:34](https://github.com/the-craftlab/pipecraft/bl
 function createSetupSummary(repository, permissions, settings, autoPromote, context): SetupSummary
 ```
 
-Defined in: [utils/messaging.ts:193](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L193)
+Defined in: [utils/messaging.ts:193](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L193)
 
 Create setup summary
 
@@ -266,7 +266,7 @@ Create setup summary
 function detectPersona(context): UserPersona
 ```
 
-Defined in: [utils/messaging.ts:68](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L68)
+Defined in: [utils/messaging.ts:68](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L68)
 
 Detect user persona based on context clues
 
@@ -302,7 +302,7 @@ Detect user persona based on context clues
 function formatMessage(message, severity, context): string
 ```
 
-Defined in: [utils/messaging.ts:91](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L91)
+Defined in: [utils/messaging.ts:91](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L91)
 
 Format message based on persona and severity
 
@@ -332,7 +332,7 @@ Format message based on persona and severity
 function formatNextSteps(steps, context): string
 ```
 
-Defined in: [utils/messaging.ts:170](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L170)
+Defined in: [utils/messaging.ts:170](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L170)
 
 Format next steps based on persona
 
@@ -358,7 +358,7 @@ Format next steps based on persona
 function formatQuickSuccess(repository, context): string
 ```
 
-Defined in: [utils/messaging.ts:309](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L309)
+Defined in: [utils/messaging.ts:309](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L309)
 
 Simple success message for when everything is already configured
 
@@ -384,7 +384,7 @@ Simple success message for when everything is already configured
 function formatSetupSummary(summary, context): string
 ```
 
-Defined in: [utils/messaging.ts:248](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L248)
+Defined in: [utils/messaging.ts:248](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L248)
 
 Format the complete setup summary
 
@@ -410,7 +410,7 @@ Format the complete setup summary
 function formatStatusTable(items, context): string
 ```
 
-Defined in: [utils/messaging.ts:121](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/messaging.ts#L121)
+Defined in: [utils/messaging.ts:121](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/messaging.ts#L121)
 
 Create a clean status table
 

--- a/docs/docs/api/utils/preflight.md
+++ b/docs/docs/api/utils/preflight.md
@@ -19,7 +19,7 @@ on how to resolve them.
 
 ### PreflightChecks
 
-Defined in: [utils/preflight.ts:47](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L47)
+Defined in: [utils/preflight.ts:47](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L47)
 
 Collection of all pre-flight check results.
 
@@ -34,7 +34,7 @@ before workflows can be generated.
 canWriteGithubDir: PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:61](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L61)
+Defined in: [utils/preflight.ts:61](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L61)
 
 .github/workflows directory is writable
 
@@ -44,7 +44,7 @@ Defined in: [utils/preflight.ts:61](https://github.com/the-craftlab/pipecraft/bl
 configExists: PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:49](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L49)
+Defined in: [utils/preflight.ts:49](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L49)
 
 Configuration file exists and is discoverable
 
@@ -54,7 +54,7 @@ Configuration file exists and is discoverable
 configValid: PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:52](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L52)
+Defined in: [utils/preflight.ts:52](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L52)
 
 Configuration file is valid and has required fields
 
@@ -64,7 +64,7 @@ Configuration file is valid and has required fields
 hasGitRemote: PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:58](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L58)
+Defined in: [utils/preflight.ts:58](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L58)
 
 Git remote (origin) is configured
 
@@ -74,7 +74,7 @@ Git remote (origin) is configured
 inGitRepo: PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:55](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L55)
+Defined in: [utils/preflight.ts:55](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L55)
 
 Current directory is a git repository
 
@@ -82,7 +82,7 @@ Current directory is a git repository
 
 ### PreflightResult
 
-Defined in: [utils/preflight.ts:30](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L30)
+Defined in: [utils/preflight.ts:30](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L30)
 
 Result of a single pre-flight check.
 
@@ -97,7 +97,7 @@ for resolving failures.
 message: string
 ```
 
-Defined in: [utils/preflight.ts:35](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L35)
+Defined in: [utils/preflight.ts:35](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L35)
 
 Human-readable description of the check result
 
@@ -107,7 +107,7 @@ Human-readable description of the check result
 passed: boolean
 ```
 
-Defined in: [utils/preflight.ts:32](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L32)
+Defined in: [utils/preflight.ts:32](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L32)
 
 Whether the check passed
 
@@ -117,7 +117,7 @@ Whether the check passed
 optional suggestion: string;
 ```
 
-Defined in: [utils/preflight.ts:38](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L38)
+Defined in: [utils/preflight.ts:38](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L38)
 
 Optional suggestion for resolving failures
 
@@ -129,7 +129,7 @@ Optional suggestion for resolving failures
 function checkCanWriteGithubDir(): PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:310](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L310)
+Defined in: [utils/preflight.ts:310](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L310)
 
 Check if .github/workflows directory exists and is writable.
 
@@ -170,7 +170,7 @@ if (!result.passed) {
 function checkConfigExists(): PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:86](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L86)
+Defined in: [utils/preflight.ts:86](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L86)
 
 Check if PipeCraft configuration file exists.
 
@@ -207,7 +207,7 @@ if (!result.passed) {
 function checkConfigValid(): PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:126](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L126)
+Defined in: [utils/preflight.ts:126](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L126)
 
 Check if configuration file is valid and contains required fields.
 
@@ -244,7 +244,7 @@ if (!result.passed) {
 function checkHasGitRemote(): PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:251](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L251)
+Defined in: [utils/preflight.ts:251](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L251)
 
 Check if git remote named 'origin' is configured.
 
@@ -285,7 +285,7 @@ if (!result.passed) {
 function checkInGitRepo(): PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:205](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L205)
+Defined in: [utils/preflight.ts:205](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L205)
 
 Check if current directory is inside a git repository.
 
@@ -322,7 +322,7 @@ if (!result.passed) {
 function checkNodeVersion(minVersion): PreflightResult
 ```
 
-Defined in: [utils/preflight.ts:377](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L377)
+Defined in: [utils/preflight.ts:377](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L377)
 
 Check if Node.js version meets minimum requirement.
 
@@ -368,7 +368,7 @@ if (!result.passed) {
 function formatPreflightResults(checks): object
 ```
 
-Defined in: [utils/preflight.ts:470](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L470)
+Defined in: [utils/preflight.ts:470](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L470)
 
 Format pre-flight check results for human-readable display.
 
@@ -437,7 +437,7 @@ if (allPassed && nextSteps) {
 function runPreflightChecks(): PreflightChecks
 ```
 
-Defined in: [utils/preflight.ts:431](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/preflight.ts#L431)
+Defined in: [utils/preflight.ts:431](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/preflight.ts#L431)
 
 Run all pre-flight checks for workflow generation.
 

--- a/docs/docs/api/utils/skill-installer.md
+++ b/docs/docs/api/utils/skill-installer.md
@@ -4,7 +4,7 @@
 
 ### InstallOptions
 
-Defined in: [utils/skill-installer.ts:158](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L158)
+Defined in: [utils/skill-installer.ts:158](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L158)
 
 #### Properties
 
@@ -14,7 +14,7 @@ Defined in: [utils/skill-installer.ts:158](https://github.com/the-craftlab/pipec
 optional cwd: string;
 ```
 
-Defined in: [utils/skill-installer.ts:163](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L163)
+Defined in: [utils/skill-installer.ts:163](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L163)
 
 ##### force?
 
@@ -22,7 +22,7 @@ Defined in: [utils/skill-installer.ts:163](https://github.com/the-craftlab/pipec
 optional force: boolean;
 ```
 
-Defined in: [utils/skill-installer.ts:162](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L162)
+Defined in: [utils/skill-installer.ts:162](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L162)
 
 ##### global?
 
@@ -30,7 +30,7 @@ Defined in: [utils/skill-installer.ts:162](https://github.com/the-craftlab/pipec
 optional global: boolean;
 ```
 
-Defined in: [utils/skill-installer.ts:159](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L159)
+Defined in: [utils/skill-installer.ts:159](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L159)
 
 ##### local?
 
@@ -38,7 +38,7 @@ Defined in: [utils/skill-installer.ts:159](https://github.com/the-craftlab/pipec
 optional local: boolean;
 ```
 
-Defined in: [utils/skill-installer.ts:160](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L160)
+Defined in: [utils/skill-installer.ts:160](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L160)
 
 ##### targets?
 
@@ -46,13 +46,13 @@ Defined in: [utils/skill-installer.ts:160](https://github.com/the-craftlab/pipec
 optional targets: string[];
 ```
 
-Defined in: [utils/skill-installer.ts:161](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L161)
+Defined in: [utils/skill-installer.ts:161](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L161)
 
 ---
 
 ### InstallResult
 
-Defined in: [utils/skill-installer.ts:23](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L23)
+Defined in: [utils/skill-installer.ts:23](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L23)
 
 #### Properties
 
@@ -62,7 +62,7 @@ Defined in: [utils/skill-installer.ts:23](https://github.com/the-craftlab/pipecr
 optional error: string;
 ```
 
-Defined in: [utils/skill-installer.ts:27](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L27)
+Defined in: [utils/skill-installer.ts:27](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L27)
 
 ##### path
 
@@ -70,7 +70,7 @@ Defined in: [utils/skill-installer.ts:27](https://github.com/the-craftlab/pipecr
 path: string
 ```
 
-Defined in: [utils/skill-installer.ts:25](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L25)
+Defined in: [utils/skill-installer.ts:25](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L25)
 
 ##### reason?
 
@@ -78,7 +78,7 @@ Defined in: [utils/skill-installer.ts:25](https://github.com/the-craftlab/pipecr
 optional reason: string;
 ```
 
-Defined in: [utils/skill-installer.ts:29](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L29)
+Defined in: [utils/skill-installer.ts:29](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L29)
 
 ##### skipped?
 
@@ -86,7 +86,7 @@ Defined in: [utils/skill-installer.ts:29](https://github.com/the-craftlab/pipecr
 optional skipped: boolean;
 ```
 
-Defined in: [utils/skill-installer.ts:28](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L28)
+Defined in: [utils/skill-installer.ts:28](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L28)
 
 ##### success
 
@@ -94,7 +94,7 @@ Defined in: [utils/skill-installer.ts:28](https://github.com/the-craftlab/pipecr
 success: boolean
 ```
 
-Defined in: [utils/skill-installer.ts:26](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L26)
+Defined in: [utils/skill-installer.ts:26](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L26)
 
 ##### target
 
@@ -102,13 +102,13 @@ Defined in: [utils/skill-installer.ts:26](https://github.com/the-craftlab/pipecr
 target: string
 ```
 
-Defined in: [utils/skill-installer.ts:24](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L24)
+Defined in: [utils/skill-installer.ts:24](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L24)
 
 ---
 
 ### SkillTarget
 
-Defined in: [utils/skill-installer.ts:15](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L15)
+Defined in: [utils/skill-installer.ts:15](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L15)
 
 #### Properties
 
@@ -118,7 +118,7 @@ Defined in: [utils/skill-installer.ts:15](https://github.com/the-craftlab/pipecr
 optional configFile: string;
 ```
 
-Defined in: [utils/skill-installer.ts:20](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L20)
+Defined in: [utils/skill-installer.ts:20](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L20)
 
 ##### displayName
 
@@ -126,7 +126,7 @@ Defined in: [utils/skill-installer.ts:20](https://github.com/the-craftlab/pipecr
 displayName: string
 ```
 
-Defined in: [utils/skill-installer.ts:17](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L17)
+Defined in: [utils/skill-installer.ts:17](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L17)
 
 ##### globalPath
 
@@ -134,7 +134,7 @@ Defined in: [utils/skill-installer.ts:17](https://github.com/the-craftlab/pipecr
 globalPath: string
 ```
 
-Defined in: [utils/skill-installer.ts:18](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L18)
+Defined in: [utils/skill-installer.ts:18](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L18)
 
 ##### localPath
 
@@ -142,7 +142,7 @@ Defined in: [utils/skill-installer.ts:18](https://github.com/the-craftlab/pipecr
 localPath: string
 ```
 
-Defined in: [utils/skill-installer.ts:19](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L19)
+Defined in: [utils/skill-installer.ts:19](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L19)
 
 ##### name
 
@@ -150,7 +150,7 @@ Defined in: [utils/skill-installer.ts:19](https://github.com/the-craftlab/pipecr
 name: string
 ```
 
-Defined in: [utils/skill-installer.ts:16](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L16)
+Defined in: [utils/skill-installer.ts:16](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L16)
 
 ## Variables
 
@@ -160,7 +160,7 @@ Defined in: [utils/skill-installer.ts:16](https://github.com/the-craftlab/pipecr
 const SKILL_TARGETS: SkillTarget[]
 ```
 
-Defined in: [utils/skill-installer.ts:35](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L35)
+Defined in: [utils/skill-installer.ts:35](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L35)
 
 Supported AI coding assistant targets
 
@@ -172,7 +172,7 @@ Supported AI coding assistant targets
 function installSkills(options): InstallResult[]
 ```
 
-Defined in: [utils/skill-installer.ts:169](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L169)
+Defined in: [utils/skill-installer.ts:169](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L169)
 
 Install Pipecraft skills for AI coding assistants
 
@@ -194,7 +194,7 @@ Install Pipecraft skills for AI coding assistants
 function listSkillTargets(): object[]
 ```
 
-Defined in: [utils/skill-installer.ts:226](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L226)
+Defined in: [utils/skill-installer.ts:226](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L226)
 
 List available skill targets and their status
 
@@ -210,7 +210,7 @@ List available skill targets and their status
 function uninstallSkills(options): InstallResult[]
 ```
 
-Defined in: [utils/skill-installer.ts:245](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/skill-installer.ts#L245)
+Defined in: [utils/skill-installer.ts:245](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/skill-installer.ts#L245)
 
 Uninstall skills from all targets
 

--- a/docs/docs/api/utils/versioning.md
+++ b/docs/docs/api/utils/versioning.md
@@ -18,7 +18,7 @@ bump versions when code is promoted through the pipeline.
 
 ### VersionManager
 
-Defined in: [utils/versioning.ts:46](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L46)
+Defined in: [utils/versioning.ts:46](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L46)
 
 Manager for semantic versioning and release automation.
 
@@ -51,7 +51,7 @@ console.log(`Next version: ${version} (${type} bump)`)
 new VersionManager(config): VersionManager;
 ```
 
-Defined in: [utils/versioning.ts:54](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L54)
+Defined in: [utils/versioning.ts:54](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L54)
 
 Create a new VersionManager instance.
 
@@ -75,7 +75,7 @@ PipeCraft configuration object
 calculateNextVersion(): object;
 ```
 
-Defined in: [utils/versioning.ts:382](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L382)
+Defined in: [utils/versioning.ts:382](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L382)
 
 Calculate the next version based on conventional commits.
 
@@ -115,7 +115,7 @@ console.log(`Next ${type} version: ${version}`)
 generateCommitlintConfig(): string;
 ```
 
-Defined in: [utils/versioning.ts:162](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L162)
+Defined in: [utils/versioning.ts:162](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L162)
 
 Generate commitlint configuration file content.
 
@@ -143,7 +143,7 @@ JavaScript module string ready to write to commitlint.config.js
 generateHuskyConfig(): string;
 ```
 
-Defined in: [utils/versioning.ts:201](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L201)
+Defined in: [utils/versioning.ts:201](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L201)
 
 Generate husky commit-msg hook script.
 
@@ -163,7 +163,7 @@ Shell script string ready to write to .husky/commit-msg
 generateReleaseItConfig(): string;
 ```
 
-Defined in: [utils/versioning.ts:79](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L79)
+Defined in: [utils/versioning.ts:79](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L79)
 
 Generate release-it configuration file content.
 
@@ -197,7 +197,7 @@ writeFileSync('.release-it.cjs', config)
 getCurrentVersion(): string;
 ```
 
-Defined in: [utils/versioning.ts:353](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L353)
+Defined in: [utils/versioning.ts:353](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L353)
 
 Get the current version from git tags.
 
@@ -223,7 +223,7 @@ console.log(`Current version: v${currentVersion}`)
 setupVersionManagement(): void;
 ```
 
-Defined in: [utils/versioning.ts:231](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L231)
+Defined in: [utils/versioning.ts:231](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L231)
 
 Setup version management infrastructure.
 
@@ -259,7 +259,7 @@ versionManager.setupVersionManagement()
 validateConventionalCommits(): boolean;
 ```
 
-Defined in: [utils/versioning.ts:320](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/versioning.ts#L320)
+Defined in: [utils/versioning.ts:320](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/versioning.ts#L320)
 
 Validate that recent commits follow conventional commit format.
 

--- a/docs/docs/api/utils/workflow-semantics.md
+++ b/docs/docs/api/utils/workflow-semantics.md
@@ -14,7 +14,7 @@ This includes:
 
 ### SemanticError
 
-Defined in: [utils/workflow-semantics.ts:16](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L16)
+Defined in: [utils/workflow-semantics.ts:16](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L16)
 
 #### Properties
 
@@ -24,7 +24,7 @@ Defined in: [utils/workflow-semantics.ts:16](https://github.com/the-craftlab/pip
 code: string
 ```
 
-Defined in: [utils/workflow-semantics.ts:18](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L18)
+Defined in: [utils/workflow-semantics.ts:18](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L18)
 
 ##### location?
 
@@ -32,7 +32,7 @@ Defined in: [utils/workflow-semantics.ts:18](https://github.com/the-craftlab/pip
 optional location: string;
 ```
 
-Defined in: [utils/workflow-semantics.ts:20](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L20)
+Defined in: [utils/workflow-semantics.ts:20](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L20)
 
 ##### message
 
@@ -40,7 +40,7 @@ Defined in: [utils/workflow-semantics.ts:20](https://github.com/the-craftlab/pip
 message: string
 ```
 
-Defined in: [utils/workflow-semantics.ts:19](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L19)
+Defined in: [utils/workflow-semantics.ts:19](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L19)
 
 ##### type
 
@@ -48,13 +48,13 @@ Defined in: [utils/workflow-semantics.ts:19](https://github.com/the-craftlab/pip
 type: 'error'
 ```
 
-Defined in: [utils/workflow-semantics.ts:17](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L17)
+Defined in: [utils/workflow-semantics.ts:17](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L17)
 
 ---
 
 ### SemanticValidationResult
 
-Defined in: [utils/workflow-semantics.ts:30](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L30)
+Defined in: [utils/workflow-semantics.ts:30](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L30)
 
 #### Properties
 
@@ -64,7 +64,7 @@ Defined in: [utils/workflow-semantics.ts:30](https://github.com/the-craftlab/pip
 errors: SemanticError[];
 ```
 
-Defined in: [utils/workflow-semantics.ts:32](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L32)
+Defined in: [utils/workflow-semantics.ts:32](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L32)
 
 ##### valid
 
@@ -72,7 +72,7 @@ Defined in: [utils/workflow-semantics.ts:32](https://github.com/the-craftlab/pip
 valid: boolean
 ```
 
-Defined in: [utils/workflow-semantics.ts:31](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L31)
+Defined in: [utils/workflow-semantics.ts:31](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L31)
 
 ##### warnings
 
@@ -80,13 +80,13 @@ Defined in: [utils/workflow-semantics.ts:31](https://github.com/the-craftlab/pip
 warnings: SemanticWarning[];
 ```
 
-Defined in: [utils/workflow-semantics.ts:33](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L33)
+Defined in: [utils/workflow-semantics.ts:33](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L33)
 
 ---
 
 ### SemanticWarning
 
-Defined in: [utils/workflow-semantics.ts:23](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L23)
+Defined in: [utils/workflow-semantics.ts:23](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L23)
 
 #### Properties
 
@@ -96,7 +96,7 @@ Defined in: [utils/workflow-semantics.ts:23](https://github.com/the-craftlab/pip
 code: string
 ```
 
-Defined in: [utils/workflow-semantics.ts:25](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L25)
+Defined in: [utils/workflow-semantics.ts:25](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L25)
 
 ##### location?
 
@@ -104,7 +104,7 @@ Defined in: [utils/workflow-semantics.ts:25](https://github.com/the-craftlab/pip
 optional location: string;
 ```
 
-Defined in: [utils/workflow-semantics.ts:27](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L27)
+Defined in: [utils/workflow-semantics.ts:27](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L27)
 
 ##### message
 
@@ -112,7 +112,7 @@ Defined in: [utils/workflow-semantics.ts:27](https://github.com/the-craftlab/pip
 message: string
 ```
 
-Defined in: [utils/workflow-semantics.ts:26](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L26)
+Defined in: [utils/workflow-semantics.ts:26](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L26)
 
 ##### type
 
@@ -120,7 +120,7 @@ Defined in: [utils/workflow-semantics.ts:26](https://github.com/the-craftlab/pip
 type: 'warning'
 ```
 
-Defined in: [utils/workflow-semantics.ts:24](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L24)
+Defined in: [utils/workflow-semantics.ts:24](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L24)
 
 ## Functions
 
@@ -130,7 +130,7 @@ Defined in: [utils/workflow-semantics.ts:24](https://github.com/the-craftlab/pip
 function validateJobDependencies(yamlContent): SemanticValidationResult
 ```
 
-Defined in: [utils/workflow-semantics.ts:259](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L259)
+Defined in: [utils/workflow-semantics.ts:259](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L259)
 
 Validate job dependencies in a workflow.
 
@@ -172,7 +172,7 @@ if (!result.valid) {
 function validateWorkflowSemantics(yamlContent): SemanticValidationResult
 ```
 
-Defined in: [utils/workflow-semantics.ts:295](https://github.com/the-craftlab/pipecraft/blob/b7312a6766bca4e83d219560237c5ba10f0b57b8/src/utils/workflow-semantics.ts#L295)
+Defined in: [utils/workflow-semantics.ts:295](https://github.com/the-craftlab/pipecraft/blob/main/src/utils/workflow-semantics.ts#L295)
 
 Validate a complete workflow for semantic correctness.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "typedoc": "typedoc --options typedoc.json"
+    "typedoc": "typedoc --options typedoc.json && prettier --write \"docs/api/**/*.md\""
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
@@ -29,6 +29,7 @@
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
     "docusaurus-plugin-typedoc": "^1.4.2",
+    "prettier": "2.8.8",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "~5.6.2"

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       docusaurus-plugin-typedoc:
         specifier: ^1.4.2
         version: 1.4.2(typedoc-plugin-markdown@4.9.0(typedoc@0.28.14(typescript@5.6.3)))
+      prettier:
+        specifier: 2.8.8
+        version: 2.8.8
       typedoc:
         specifier: ^0.28.14
         version: 0.28.14(typescript@5.6.3)
@@ -4098,6 +4101,11 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
@@ -10410,6 +10418,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prettier@2.8.8: {}
 
   pretty-error@4.0.0:
     dependencies:

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -17,6 +17,7 @@
   "includeVersion": false,
   "githubPages": false,
   "disableSources": false,
+  "gitRevision": "main",
   "sourceLinkTemplate": "https://github.com/the-craftlab/pipecraft/blob/{gitRevision}/{path}#L{line}",
   "useCodeBlocks": true,
   "expandObjects": false,


### PR DESCRIPTION
The generated API reference perpetually looked 'drifted' for two non-content reasons: source links embedded the current commit SHA (`{gitRevision}`) so every commit changed every `api/*.md`, and typedoc emits non-prettier markdown so output never matched the committed (formatted) files (and tripped the prettier pre-commit check).

Fixes:
- pin source links to the `main` branch (typedoc `gitRevision: "main"`)
- run prettier on typedoc output (prettier added to the docs workspace; `typedoc` script formats `docs/api` after generating)
- regenerate the reference with both applied

`pnpm docs:typedoc` is now idempotent (second run = zero diff), so 'regenerate + git diff' is a real drift check and CI prettier won't fail on regen. 509 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)