### PR TITLE
fix(ci): run test-docs on docs PRs (tolerate skipped version dep)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -277,10 +277,14 @@ jobs:
     needs:
       - changes
       - version
+    # always() so a skipped `version` dependency (version is skipped on pull_request
+    # events) doesn't cascade-skip this job — without it, docs PRs never run the docs
+    # build, and the gate treats the skip as a pass.
     if: ${{
-        needs.changes.outputs.docs == 'true' ||
+        always() &&
+        (needs.changes.outputs.docs == 'true' ||
         (needs.version.result == 'success' &&
-        needs.version.outputs.version != '')
+        needs.version.outputs.version != ''))
       }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Run test-docs on docs PRs (tolerate skipped version dependency)

`test-docs` declares `needs: [changes, version]`, but the managed `version` job is skipped on `pull_request` events (`if: github.event_name != 'pull_request'`). In GitHub Actions, a job whose dependency is **skipped** is itself skipped unless its `if` uses `always()` — so `test-docs` skipped on every docs PR even when `changes.outputs.docs == 'true'`.

This surfaced on #439: change-detection correctly reported `docs: true`, but `test-docs` skipped anyway. Now that `gate` is the required check (and treats a skipped job as "ok"), a broken docs change could merge **without the docs build ever running**.

Fix: add `always()` to `test-docs`'s `if` so it evaluates on its own condition regardless of the skipped `version` need. Behaviour:
- docs PR → runs ✅ (was skipping)
- non-docs PR → skips (correct)
- push to develop/main with a version → runs (deploy path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
