### PR TITLE
feat(calculate-version): resolve version from promotion merge (B2) [DRAFT — verify in CI]

### DIFF
--- a/actions/calculate-version/action.yml
+++ b/actions/calculate-version/action.yml
@@ -95,6 +95,40 @@ runs:
           echo "version=$TAG" >> $GITHUB_OUTPUT
         fi
 
+    - name: Get version from promotion merge (B2)
+      id: get_version_promotion
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == ''
+      shell: bash
+      run: |
+        # When a promotion PR is merged as a MERGE COMMIT, HEAD is the merge commit (which
+        # carries no tag), but its second parent IS the promoted, tagged commit. Resolve the
+        # version precisely from there (and from the 'release/{src}-to-{tgt}-{version}' branch
+        # name) BEFORE falling back to release-it or nearest-reachable-tag — both of which can
+        # pick the wrong version on a merge-commit promotion. No-op on fast-forward promotions
+        # (no second parent) and normal pushes.
+        if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+          # 1. Exact tag on the merged (second-parent) commit
+          PARENT_TAG=$(git tag --points-at HEAD^2 | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$PARENT_TAG" ]; then
+            echo "Found tag on promotion merge parent: $PARENT_TAG"
+            echo "version=$PARENT_TAG" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # 2. Version encoded in the release branch name, from the merge commit subject
+          SUBJECT=$(git log -1 --pretty=%s HEAD)
+          BRANCH_VERSION=$(echo "$SUBJECT" | grep -oE 'release/[A-Za-z0-9._/-]+-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$BRANCH_VERSION" ]; then
+            echo "Parsed version from promotion branch name: v$BRANCH_VERSION"
+            echo "version=v$BRANCH_VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Merge commit found but no version resolved from parent tag or branch name"
+        else
+          echo "HEAD is not a merge commit; skipping promotion-merge version resolution"
+        fi
+
     - name: Set up minimal package.json
       shell: bash
       run: |
@@ -104,7 +138,7 @@ runs:
         }' > package.json
 
     - name: Get version
-      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == ''
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_promotion.outputs.version == ''
       id: get_version_new
       shell: bash
       run: |
@@ -124,7 +158,7 @@ runs:
         fi
 
     - name: Get nearest reachable tag
-      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_new.outputs.version == ''
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_promotion.outputs.version == '' && steps.get_version_new.outputs.version == ''
       id: get_version_nearest
       shell: bash
       run: |
@@ -152,6 +186,9 @@ runs:
         elif [ -n "${{ steps.get_version_old.outputs.version }}" ]; then
           echo "Using tag version: ${{ steps.get_version_old.outputs.version }}"
           echo "version=${{ steps.get_version_old.outputs.version }}" >> $GITHUB_OUTPUT
+        elif [ -n "${{ steps.get_version_promotion.outputs.version }}" ]; then
+          echo "Using promotion-merge version: ${{ steps.get_version_promotion.outputs.version }}"
+          echo "version=${{ steps.get_version_promotion.outputs.version }}" >> $GITHUB_OUTPUT
         elif [ -n "${{ steps.get_version_new.outputs.version }}" ]; then
           echo "Using calculated version: ${{ steps.get_version_new.outputs.version }}"
           echo "version=${{ steps.get_version_new.outputs.version }}" >> $GITHUB_OUTPUT

--- a/src/templates/actions/calculate-version.yml.tpl.ts
+++ b/src/templates/actions/calculate-version.yml.tpl.ts
@@ -150,6 +150,40 @@ runs:
           echo "version=$TAG" >> $GITHUB_OUTPUT
         fi
 
+    - name: Get version from promotion merge (B2)
+      id: get_version_promotion
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == ''
+      shell: bash
+      run: |
+        # When a promotion PR is merged as a MERGE COMMIT, HEAD is the merge commit (which
+        # carries no tag), but its second parent IS the promoted, tagged commit. Resolve the
+        # version precisely from there (and from the 'release/{src}-to-{tgt}-{version}' branch
+        # name) BEFORE falling back to release-it or nearest-reachable-tag — both of which can
+        # pick the wrong version on a merge-commit promotion. No-op on fast-forward promotions
+        # (no second parent) and normal pushes.
+        if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+          # 1. Exact tag on the merged (second-parent) commit
+          PARENT_TAG=$(git tag --points-at HEAD^2 | grep -E '^v[0-9]+\\.[0-9]+\\.[0-9]+$' | head -1 || true)
+          if [ -n "$PARENT_TAG" ]; then
+            echo "Found tag on promotion merge parent: $PARENT_TAG"
+            echo "version=$PARENT_TAG" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # 2. Version encoded in the release branch name, from the merge commit subject
+          SUBJECT=$(git log -1 --pretty=%s HEAD)
+          BRANCH_VERSION=$(echo "$SUBJECT" | grep -oE 'release/[A-Za-z0-9._/-]+-[0-9]+\\.[0-9]+\\.[0-9]+' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+$' | head -1 || true)
+          if [ -n "$BRANCH_VERSION" ]; then
+            echo "Parsed version from promotion branch name: v$BRANCH_VERSION"
+            echo "version=v$BRANCH_VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Merge commit found but no version resolved from parent tag or branch name"
+        else
+          echo "HEAD is not a merge commit; skipping promotion-merge version resolution"
+        fi
+
     - name: Set up minimal package.json
       shell: bash
       run: |
@@ -159,7 +193,7 @@ runs:
         }' > package.json
 
     - name: Get version
-      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == ''
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_promotion.outputs.version == ''
       id: get_version_new
       shell: bash
       run: |
@@ -179,7 +213,7 @@ runs:
         fi
 
     - name: Get nearest reachable tag
-      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_new.outputs.version == ''
+      if: steps.check_input_version.outputs.version == '' && steps.get_version_old.outputs.version == '' && steps.get_version_promotion.outputs.version == '' && steps.get_version_new.outputs.version == ''
       id: get_version_nearest
       shell: bash
       run: |
@@ -207,6 +241,9 @@ runs:
         elif [ -n "\${{ steps.get_version_old.outputs.version }}" ]; then
           echo "Using tag version: \${{ steps.get_version_old.outputs.version }}"
           echo "version=\${{ steps.get_version_old.outputs.version }}" >> $GITHUB_OUTPUT
+        elif [ -n "\${{ steps.get_version_promotion.outputs.version }}" ]; then
+          echo "Using promotion-merge version: \${{ steps.get_version_promotion.outputs.version }}"
+          echo "version=\${{ steps.get_version_promotion.outputs.version }}" >> $GITHUB_OUTPUT
         elif [ -n "\${{ steps.get_version_new.outputs.version }}" ]; then
           echo "Using calculated version: \${{ steps.get_version_new.outputs.version }}"
           echo "version=\${{ steps.get_version_new.outputs.version }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## B2 — resolve the promoted version from a merge-commit promotion

> ⚠️ **Draft on purpose.** This is composite-action shell whose behaviour only matters on a real merge-commit promotion. Please exercise it in CI (see below) before marking ready / merging — do not auto-merge.

### Problem
On the manual-merge prod path (`autoPromote: false`, `main: false`), a release PR merged as a **merge commit** leaves `HEAD` with no tag. `calculate-version` then fell through to `git describe --tags --abbrev=0` (B1), which finds the *nearest* tag by topology — and can resolve the **wrong** version. B1 fixed "missing release" but opened "wrong release".

### Fix
A new step `get_version_promotion` runs between the exact-tag-on-`HEAD` lookup and the release-it / nearest-tag fallbacks:
1. exact tag on the merge's **second parent** (`HEAD^2`, i.e. the promoted/tagged commit)
2. version parsed from the `release/{src}-to-{tgt}-{version}` branch name in the merge subject

It's a **no-op** on fast-forward promotions (no `HEAD^2`), `workflow_dispatch` (`inputs.version` wins), and normal pushes. If neither resolves, it falls back to the existing release-it → nearest-tag chain. Resolution priority is updated in `set_version`.

### How to verify (the deliberate test)
On a throwaway branch chain (e.g. `dev2 → main2`):
1. Tag a commit on the source (`vX.Y.Z`) and run the promote action with `autoPromote: false`.
2. Merge the resulting `release/dev2-to-main2-X.Y.Z` PR **as a merge commit** (not squash/rebase).
3. On the target's pipeline run, open the `version` job → `Get version from promotion merge (B2)` step and confirm it logs `Found tag on promotion merge parent: vX.Y.Z` (or the branch-name parse) and that `set_version` reports `vX.Y.Z` — not a stale/nearest tag.
4. Sanity: a fast-forward promotion and a `workflow_dispatch` run should both show the step as a no-op / input-driven.

Structural checks pass locally (build, `sync-actions:check`, 548 tests). The generated `actions/calculate-version/action.yml` is regenerated from the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
