### PR TITLE
fix(cli): auto-discover .pipecraftrc.json/.yml configs (don't force bare .pipecraftrc)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,7 +106,11 @@ program
 
 // Global options
 program
-  .option('-c, --config <path>', 'path to config file', '.pipecraftrc')
+  // No default: when omitted, loadConfig() lets cosmiconfig search and discover any
+  // supported format (.pipecraftrc, .pipecraftrc.json/.yml/.yaml/.js, pipecraft.config.js,
+  // package.json#pipecraft). A hardcoded '.pipecraftrc' default would force an exact-file
+  // load and ENOENT on the common .pipecraftrc.json case.
+  .option('-c, --config <path>', 'path to config file (default: auto-discovered)')
   .option(
     '-p, --pipeline <path>',
     'path to existing pipeline file for merging',

--- a/tests/integration/cli-exit-codes.test.ts
+++ b/tests/integration/cli-exit-codes.test.ts
@@ -65,6 +65,38 @@ describe('CLI Exit Codes', () => {
       expect(result.status).toBe(0)
     })
 
+    it('auto-discovers a .pipecraftrc.json config (not bare .pipecraftrc)', () => {
+      // Regression: the CLI used to default -c to the literal '.pipecraftrc', forcing an
+      // exact-file load that ENOENT'd on the common .pipecraftrc.json case. With no
+      // default, cosmiconfig discovers any supported format.
+      const config = {
+        ciProvider: 'github',
+        mergeStrategy: 'fast-forward',
+        requireConventionalCommits: true,
+        initialBranch: 'develop',
+        finalBranch: 'main',
+        branchFlow: ['develop', 'main'],
+        semver: { bumpRules: { feat: 'minor', fix: 'patch' } },
+        domains: { api: { paths: ['apps/api/**'], description: 'API', testable: true } }
+      }
+      writeFileSync(join(testDir, '.pipecraftrc.json'), JSON.stringify(config))
+
+      const validate = spawnSync('node', [cliPath, 'validate'], {
+        cwd: testDir,
+        encoding: 'utf8',
+        timeout: 10000
+      })
+      expect(validate.status).toBe(0)
+
+      const generate = spawnSync('node', [cliPath, 'generate', '--skip-checks'], {
+        cwd: testDir,
+        encoding: 'utf8',
+        timeout: 30000
+      })
+      expect(generate.status).toBe(0)
+      expect(existsSync(join(testDir, '.github', 'workflows', 'pipeline.yml'))).toBe(true)
+    })
+
     it('should exit 1 when config is invalid', () => {
       // Create invalid config (missing required fields)
       const invalidConfig = {


### PR DESCRIPTION
The `-c/--config` option defaulted to the literal `.pipecraftrc`, so `validate`/`generate`/`doctor` ENOENT'd on `.pipecraftrc.json` (and `.yml`/`.yaml`/`.js`) — every format the docs promise except bare `.pipecraftrc`. Found while testing the example repos (all use `.pipecraftrc.json`).

Fix: drop the default so cosmiconfig `.search()` discovers any supported format; explicit `-c` still loads an exact path. Added a CLI integration test using `.pipecraftrc.json` (existing tests only used bare `.pipecraftrc`).

549 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)