### PR TITLE
fix(actions): promotion + branch-setup robustness (found via example flavors)

### DIFF
--- a/actions/manage-branch/action.yml
+++ b/actions/manage-branch/action.yml
@@ -69,6 +69,12 @@ runs:
         
         echo "✅ Input validation passed"
 
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
     - name: Perform Branch Action
       id: branch-action
       shell: bash

--- a/actions/promote-branch/action.yml
+++ b/actions/promote-branch/action.yml
@@ -29,7 +29,7 @@ inputs:
   tempBranchPattern:
     description: 'Pattern for temp branch name'
     required: false
-    default: 'release/{source}-to-{target}-{version}'
+    default: 'pipecraft-promote/{source}-to-{target}-{version}'
   token:
     description: 'GitHub token for authentication'
     required: false
@@ -185,6 +185,13 @@ runs:
           echo "prUrl=$PR_URL" >> $GITHUB_OUTPUT
           echo "✅ Created PR #$PR_NUMBER"
           echo "🔗 URL: $PR_URL"
+        elif echo "$PR_URL" | grep -qiE "No commits between"; then
+          # '$TARGET' is already even with '$SOURCE' — there is nothing to promote.
+          # This is a no-op success (also covers re-runs), not a failure. Downstream
+          # steps tolerate an empty PR number (the ff-merge is a no-op when even).
+          echo "ℹ️  '$TARGET' is already up to date with '$SOURCE' — nothing to promote."
+          echo "prNumber=" >> $GITHUB_OUTPUT
+          echo "prUrl=" >> $GITHUB_OUTPUT
         else
           echo "❌ Failed to create PR"
           echo "Error output:"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -491,12 +491,17 @@ program
           }
         }
 
-        // Push branch to remote if it doesn't exist there
-        try {
-          console.log(`📤 Checking if '${branch}' exists on remote...`)
-          execSync(`git ls-remote --heads origin ${branch}`, { stdio: 'pipe' })
+        // Push branch to remote if it doesn't exist there.
+        // NOTE: `git ls-remote --heads origin <branch>` exits 0 even when the branch is
+        // absent (empty output) — so we must check the OUTPUT, not whether it throws.
+        // The previous `try/catch` always took the "exists" path and never pushed.
+        console.log(`📤 Checking if '${branch}' exists on remote...`)
+        const remoteRef = execSync(`git ls-remote --heads origin ${branch}`, {
+          encoding: 'utf8'
+        }).trim()
+        if (remoteRef.length > 0) {
           console.log(`✅ Branch '${branch}' already exists on remote`)
-        } catch (error: any) {
+        } else {
           console.log(`🚀 Pushing branch '${branch}' to remote...`)
           execSync(`git push -u origin ${branch}`, { stdio: 'inherit' })
           console.log(`✅ Pushed branch '${branch}' to remote`)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,7 +106,11 @@ program
 
 // Global options
 program
-  .option('-c, --config <path>', 'path to config file', '.pipecraftrc')
+  // No default: when omitted, loadConfig() lets cosmiconfig search and discover any
+  // supported format (.pipecraftrc, .pipecraftrc.json/.yml/.yaml/.js, pipecraft.config.js,
+  // package.json#pipecraft). A hardcoded '.pipecraftrc' default would force an exact-file
+  // load and ENOENT on the common .pipecraftrc.json case.
+  .option('-c, --config <path>', 'path to config file (default: auto-discovered)')
   .option(
     '-p, --pipeline <path>',
     'path to existing pipeline file for merging',

--- a/src/templates/actions/manage-branch.yml.tpl.ts
+++ b/src/templates/actions/manage-branch.yml.tpl.ts
@@ -92,6 +92,12 @@ const branchActionTemplate = (ctx: any) => {
             
             echo "✅ Input validation passed"
 
+        - name: Configure Git
+          shell: bash
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
         - name: Perform Branch Action
           id: branch-action
           shell: bash

--- a/src/templates/actions/promote-branch.yml.tpl.ts
+++ b/src/templates/actions/promote-branch.yml.tpl.ts
@@ -52,7 +52,7 @@ const promoteBranchActionTemplate = (ctx: any) => {
       tempBranchPattern:
         description: 'Pattern for temp branch name'
         required: false
-        default: 'release/{source}-to-{target}-{version}'
+        default: 'pipecraft-promote/{source}-to-{target}-{version}'
       token:
         description: 'GitHub token for authentication'
         required: false
@@ -212,6 +212,13 @@ const promoteBranchActionTemplate = (ctx: any) => {
               echo "prUrl=\$PR_URL" >> \$GITHUB_OUTPUT
               echo "✅ Created PR #\$PR_NUMBER"
               echo "🔗 URL: \$PR_URL"
+            elif echo "\$PR_URL" | grep -qiE "No commits between"; then
+              # '\$TARGET' is already even with '\$SOURCE' — there is nothing to promote.
+              # This is a no-op success (also covers re-runs), not a failure. Downstream
+              # steps tolerate an empty PR number (the ff-merge is a no-op when even).
+              echo "ℹ️  '\$TARGET' is already up to date with '\$SOURCE' — nothing to promote."
+              echo "prNumber=" >> \$GITHUB_OUTPUT
+              echo "prUrl=" >> \$GITHUB_OUTPUT
             else
               echo "❌ Failed to create PR"
               echo "Error output:"

--- a/tests/integration/cli-exit-codes.test.ts
+++ b/tests/integration/cli-exit-codes.test.ts
@@ -65,6 +65,38 @@ describe('CLI Exit Codes', () => {
       expect(result.status).toBe(0)
     })
 
+    it('auto-discovers a .pipecraftrc.json config (not bare .pipecraftrc)', () => {
+      // Regression: the CLI used to default -c to the literal '.pipecraftrc', forcing an
+      // exact-file load that ENOENT'd on the common .pipecraftrc.json case. With no
+      // default, cosmiconfig discovers any supported format.
+      const config = {
+        ciProvider: 'github',
+        mergeStrategy: 'fast-forward',
+        requireConventionalCommits: true,
+        initialBranch: 'develop',
+        finalBranch: 'main',
+        branchFlow: ['develop', 'main'],
+        semver: { bumpRules: { feat: 'minor', fix: 'patch' } },
+        domains: { api: { paths: ['apps/api/**'], description: 'API', testable: true } }
+      }
+      writeFileSync(join(testDir, '.pipecraftrc.json'), JSON.stringify(config))
+
+      const validate = spawnSync('node', [cliPath, 'validate'], {
+        cwd: testDir,
+        encoding: 'utf8',
+        timeout: 10000
+      })
+      expect(validate.status).toBe(0)
+
+      const generate = spawnSync('node', [cliPath, 'generate', '--skip-checks'], {
+        cwd: testDir,
+        encoding: 'utf8',
+        timeout: 30000
+      })
+      expect(generate.status).toBe(0)
+      expect(existsSync(join(testDir, '.github', 'workflows', 'pipeline.yml'))).toBe(true)
+    })
+
     it('should exit 1 when config is invalid', () => {
       // Create invalid config (missing required fields)
       const invalidConfig = {


### PR DESCRIPTION
Bugs surfaced by getting the example repos (minimal/basic/gated) to green CI:

1. **setup** never pushed missing branches — `git ls-remote` exits 0 with empty output, so the throw-based check always assumed the branch existed. Now checks output.
2. **promote** hard-failed on `No commits between` (even branches / re-runs) — now a no-op success.
3. **promote** temp prefix `release/` collided with a `release` flow branch (git D/F conflict) — namespaced to `pipecraft-promote/`.
4. **manage-branch** did git ops with no identity — added Configure Git.

Proven by green CI on all 3 example flavors. 549 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)