### PR TITLE
test(e2e): repeatable promotion-cascade verification harness

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,34 @@
+# End-to-end verification
+
+## `verify-promotion.sh` — repeatable promotion-cascade proof
+
+Proves, against a **live** PipeCraft repo, that a change pushed to the initial branch
+actually promotes all the way through to the final branch.
+
+```bash
+tests/e2e/verify-promotion.sh <owner/repo> [domain-file-to-touch]
+
+# e.g.
+tests/e2e/verify-promotion.sh the-craftlab/pipecraft-example-basic
+tests/e2e/verify-promotion.sh the-craftlab/pipecraft-example-gated services/auth-service.js
+```
+
+What it does (idempotent — safe to re-run):
+
+1. Clones the repo into a temp dir.
+2. Resets every downstream branch to the initial branch's tip (a clean, even base).
+3. Commits a unique `feat:` touching a domain file and pushes it to the initial branch.
+4. Polls until that exact commit is reachable from the final branch — i.e. the promotion
+   cascade carried it through — then exits `0`. Times out (non-zero) if it never arrives.
+
+Requirements: `gh` authenticated with push access to the target repo, and the repo already
+set up (`pipecraft setup` + `pipecraft setup-github`). Use the disposable
+`the-craftlab/pipecraft-example-*` repos.
+
+The canonical flavors this is run against:
+
+| Repo                        | Flow                                          | Promotion    |
+| --------------------------- | --------------------------------------------- | ------------ |
+| `pipecraft-example-minimal` | develop → main                                | auto         |
+| `pipecraft-example-basic`   | develop → staging → main                      | auto         |
+| `pipecraft-example-gated`   | develop → alpha → beta → release → production | manual gates |

--- a/tests/e2e/verify-promotion.sh
+++ b/tests/e2e/verify-promotion.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# verify-promotion.sh <owner/repo> [domain-file-to-touch]
+#
+# Repeatable, self-checking end-to-end proof that a PipeCraft repo's promotion flow
+# actually moves code from the initial branch through to the final branch.
+#
+# It:
+#   1. clones the repo fresh into a temp dir
+#   2. resets every downstream branch to the initial branch's tip (a clean, even base)
+#   3. commits a unique `feat:` touching a domain file and pushes it to the initial branch
+#   4. polls until that exact commit becomes reachable from the final branch
+#      (= the promotion cascade carried it all the way through) — or fails on timeout
+#
+# Re-running it repeats the cycle from a clean base, so it is idempotent and CI-safe.
+set -euo pipefail
+
+REPO="${1:?usage: verify-promotion.sh <owner/repo> [domain-file]}"
+TOUCH_FILE="${2:-}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "📦 Cloning $REPO ..."
+gh repo clone "$REPO" "$WORK" -- -q
+cd "$WORK"
+git config user.email "ci@thecraftlab.dev"
+git config user.name "pipecraft-ci"
+
+# Read the branch flow from the committed config.
+mapfile -t FLOW < <(node -e "const c=require('./.pipecraftrc.json');process.stdout.write(c.branchFlow.join('\n'))")
+INITIAL="${FLOW[0]}"
+FINAL="${FLOW[${#FLOW[@]}-1]}"
+echo "🌿 Branch flow: ${FLOW[*]}   (initial=$INITIAL → final=$FINAL)"
+
+# Pick a domain file to touch so change detection fires (first domain's first path).
+if [ -z "$TOUCH_FILE" ]; then
+  GLOB="$(node -e "const c=require('./.pipecraftrc.json');const d=Object.values(c.domains)[0];process.stdout.write(d.paths[0])")"
+  DIR="${GLOB%%/\*\*}"
+  mkdir -p "$DIR"
+  TOUCH_FILE="$DIR/.pipecraft-promo-marker"
+fi
+
+git fetch origin -q
+BASE="$(git rev-parse "origin/$INITIAL")"
+
+echo "↩️  Resetting downstream branches to base ($BASE) ..."
+for b in "${FLOW[@]:1}"; do
+  git push origin "$BASE:refs/heads/$b" --force >/dev/null 2>&1
+  echo "   reset $b → base"
+done
+
+echo "✍️  Committing a feat on $INITIAL (touching $TOUCH_FILE) ..."
+git checkout "$INITIAL" -q
+git reset --hard "origin/$INITIAL" -q
+MARKER="promo-$(git rev-parse --short HEAD)-$RANDOM"
+echo "// promotion proof marker: $MARKER" >> "$TOUCH_FILE"
+git add "$TOUCH_FILE"
+git commit -qm "feat: verify promotion cascade ($MARKER)"
+git push origin "$INITIAL" -q
+FEAT_SHA="$(git rev-parse HEAD)"
+echo "🚀 Pushed $FEAT_SHA to $INITIAL — waiting for it to reach $FINAL via promotion ..."
+
+# Poll until the feat commit is an ancestor of the final branch (cascade complete).
+for i in $(seq 1 90); do
+  sleep 20
+  git fetch origin -q "$FINAL" 2>/dev/null || true
+  if git merge-base --is-ancestor "$FEAT_SHA" "origin/$FINAL" 2>/dev/null; then
+    echo "✅ PROOF: $FEAT_SHA reached $FINAL — promotion cascade $INITIAL → $FINAL succeeded."
+    exit 0
+  fi
+  echo "   ...still promoting (t+$((i*20))s); $FINAL at $(git rev-parse --short origin/$FINAL)"
+done
+
+echo "❌ FAIL: feat $FEAT_SHA did not reach $FINAL within the timeout."
+exit 1


### PR DESCRIPTION
Adds `tests/e2e/verify-promotion.sh` — a repeatable, self-checking proof that a PipeCraft repo's promotion flow actually moves code from the initial branch to the final branch.

Proven on `pipecraft-example-basic`: a feat pushed to develop cascaded **develop → staging → main** in ~80s. Re-runnable against any auto-promote example repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)