### PR TITLE
fix(promote/release): promotion cascade correctness (stale temp branch, release idempotency, autoPromote boolean)

### DIFF
--- a/actions/create-release/action.yml
+++ b/actions/create-release/action.yml
@@ -66,10 +66,14 @@ runs:
           RELEASE_NOTES=$(git log --pretty=format:"- %s" --no-merges)
         fi
 
-        # Create release with notes
+        # Create release with notes.
+        # Disable errexit around the gh call: composite steps run with 'bash -e', and a
+        # failed command substitution in an assignment exits IMMEDIATELY — before we can
+        # capture the exit code and run the "already exists" idempotency branch below.
+        set +e
         RELEASE_OUTPUT=$(gh release create "$VERSION" \--title "Release $VERSION" \--notes "$RELEASE_NOTES" \--latest 2>&1)
-
         RELEASE_EXIT_CODE=$?
+        set -e
 
         if [ $RELEASE_EXIT_CODE -eq 0 ]; then
           # Extract release URL from output

--- a/actions/promote-branch/action.yml
+++ b/actions/promote-branch/action.yml
@@ -108,19 +108,16 @@ runs:
         # Ensure we're on the source branch
         git checkout "$SOURCE"
 
-        # Check if temp branch already exists locally or remotely
-        if git show-ref --verify --quiet refs/heads/"$TEMP_BRANCH" || git ls-remote --heads origin "$TEMP_BRANCH" | grep -q "$TEMP_BRANCH"; then
-          echo "⚠️  Temp branch $TEMP_BRANCH already exists, using existing branch"
-          # Fetch and checkout existing branch
-          git fetch origin "$TEMP_BRANCH" 2>/dev/null || true
-          git checkout "$TEMP_BRANCH" 2>/dev/null || git checkout -b "$TEMP_BRANCH" origin/"$TEMP_BRANCH"
-        else
-          echo "📝 Creating new temp branch $TEMP_BRANCH"
-          # Create temp branch from current commit
-          git checkout -b "$TEMP_BRANCH"
-          # Push temp branch to remote
-          git push origin "$TEMP_BRANCH"
-        fi
+        # Always (re)create the temp branch at SOURCE's current tip. A branch of the
+        # same name may linger from an earlier no-op promotion pointing at an OLD commit
+        # (the manual-gate path leaves its temp branch behind). Reusing it as-is makes
+        # 'gh pr create' report "No commits between" and silently no-op, so a genuine
+        # promotion produces no gate PR. Forcing the temp branch to SOURCE keeps the
+        # promotion honest and stays idempotent on legitimate re-runs of the same version.
+        echo "📝 (Re)creating temp branch $TEMP_BRANCH at $SOURCE tip"
+        git branch -f "$TEMP_BRANCH" "$SOURCE"
+        git checkout "$TEMP_BRANCH"
+        git push --force origin "$TEMP_BRANCH"
 
         echo "tempBranch=$TEMP_BRANCH" >> $GITHUB_OUTPUT
         echo "✅ Temporary branch ready"
@@ -196,6 +193,9 @@ runs:
           echo "ℹ️  '$TARGET' is already up to date with '$SOURCE' — nothing to promote."
           echo "prNumber=" >> $GITHUB_OUTPUT
           echo "prUrl=" >> $GITHUB_OUTPUT
+          # No PR was opened against this temp branch, so delete it. Leaving it behind is
+          # what caused the stale-reuse no-op on the next same-version promotion.
+          git push origin --delete "$TEMP_BRANCH" 2>/dev/null || true
         else
           echo "❌ Failed to create PR"
           echo "Error output:"

--- a/src/templates/actions/create-release.yml.tpl.ts
+++ b/src/templates/actions/create-release.yml.tpl.ts
@@ -21,7 +21,7 @@ import type { PipecraftConfig } from '../../types/index.js'
  * @param {any} ctx - Context (not currently used)
  * @returns {string} YAML content for the composite action
  */
-const releaseActionTemplate = (ctx: any) => {
+export const releaseActionTemplate = (ctx: any) => {
   return dedent`name: 'Create Release'
     description: 'Create a GitHub release with auto-generated release notes'
     author: 'PipeCraft'
@@ -90,13 +90,17 @@ const releaseActionTemplate = (ctx: any) => {
               RELEASE_NOTES=$(git log --pretty=format:"- %s" --no-merges)
             fi
 
-            # Create release with notes
+            # Create release with notes.
+            # Disable errexit around the gh call: composite steps run with 'bash -e', and a
+            # failed command substitution in an assignment exits IMMEDIATELY — before we can
+            # capture the exit code and run the "already exists" idempotency branch below.
+            set +e
             RELEASE_OUTPUT=$(gh release create "$VERSION" \\
               --title "Release $VERSION" \\
               --notes "$RELEASE_NOTES" \\
               --latest 2>&1)
-
             RELEASE_EXIT_CODE=$?
+            set -e
 
             if [ $RELEASE_EXIT_CODE -eq 0 ]; then
               # Extract release URL from output

--- a/src/templates/actions/promote-branch.yml.tpl.ts
+++ b/src/templates/actions/promote-branch.yml.tpl.ts
@@ -20,7 +20,7 @@ import type { PipecraftConfig } from '../../types/index.js'
  * @param {any} ctx - Context (not currently used)
  * @returns {string} YAML content for the composite action
  */
-const promoteBranchActionTemplate = (ctx: any) => {
+export const promoteBranchActionTemplate = (ctx: any) => {
   return dedent`name: 'Promote Branch'
     description: 'Promote code from source to target branch via temporary branch + PR'
     author: 'PipeCraft'
@@ -131,19 +131,16 @@ const promoteBranchActionTemplate = (ctx: any) => {
             # Ensure we're on the source branch
             git checkout "\$SOURCE"
 
-            # Check if temp branch already exists locally or remotely
-            if git show-ref --verify --quiet refs/heads/"\$TEMP_BRANCH" || git ls-remote --heads origin "\$TEMP_BRANCH" | grep -q "\$TEMP_BRANCH"; then
-              echo "⚠️  Temp branch \$TEMP_BRANCH already exists, using existing branch"
-              # Fetch and checkout existing branch
-              git fetch origin "\$TEMP_BRANCH" 2>/dev/null || true
-              git checkout "\$TEMP_BRANCH" 2>/dev/null || git checkout -b "\$TEMP_BRANCH" origin/"\$TEMP_BRANCH"
-            else
-              echo "📝 Creating new temp branch \$TEMP_BRANCH"
-              # Create temp branch from current commit
-              git checkout -b "\$TEMP_BRANCH"
-              # Push temp branch to remote
-              git push origin "\$TEMP_BRANCH"
-            fi
+            # Always (re)create the temp branch at SOURCE's current tip. A branch of the
+            # same name may linger from an earlier no-op promotion pointing at an OLD commit
+            # (the manual-gate path leaves its temp branch behind). Reusing it as-is makes
+            # 'gh pr create' report "No commits between" and silently no-op, so a genuine
+            # promotion produces no gate PR. Forcing the temp branch to SOURCE keeps the
+            # promotion honest and stays idempotent on legitimate re-runs of the same version.
+            echo "📝 (Re)creating temp branch \$TEMP_BRANCH at \$SOURCE tip"
+            git branch -f "\$TEMP_BRANCH" "\$SOURCE"
+            git checkout "\$TEMP_BRANCH"
+            git push --force origin "\$TEMP_BRANCH"
 
             echo "tempBranch=\$TEMP_BRANCH" >> \$GITHUB_OUTPUT
             echo "✅ Temporary branch ready"
@@ -223,6 +220,9 @@ const promoteBranchActionTemplate = (ctx: any) => {
               echo "ℹ️  '\$TARGET' is already up to date with '\$SOURCE' — nothing to promote."
               echo "prNumber=" >> \$GITHUB_OUTPUT
               echo "prUrl=" >> \$GITHUB_OUTPUT
+              # No PR was opened against this temp branch, so delete it. Leaving it behind is
+              # what caused the stale-reuse no-op on the next same-version promotion.
+              git push origin --delete "\$TEMP_BRANCH" 2>/dev/null || true
             else
               echo "❌ Failed to create PR"
               echo "Error output:"

--- a/src/templates/workflows/pipeline.yml.tpl.ts
+++ b/src/templates/workflows/pipeline.yml.tpl.ts
@@ -369,7 +369,10 @@ export const generate = (ctx: PathBasedPipelineContext) =>
         // Tag, promote, release
         ...createTagPromoteReleaseOperations({
           branchFlow,
-          autoPromote: typeof config.autoPromote === 'object' ? config.autoPromote : {},
+          // Pass autoPromote through as-is: a global boolean (true = every hop) or a
+          // per-target map. Coercing the boolean to {} here is what made `autoPromote:
+          // true` silently behave as all-manual.
+          autoPromote: config.autoPromote,
           mergeStrategy: config.mergeStrategy,
           config
         })

--- a/src/templates/workflows/shared/operations-tag-promote.ts
+++ b/src/templates/workflows/shared/operations-tag-promote.ts
@@ -13,7 +13,7 @@ import type { PipecraftConfig } from '../../../types/index.js'
 
 export interface TagPromoteContext {
   branchFlow: string[]
-  autoPromote?: Record<string, boolean> // autoPromote settings per branch
+  autoPromote?: boolean | Record<string, boolean> // global boolean, or per-target map
   mergeStrategy?: 'fast-forward' | 'merge' // how promotions land on the target branch
   config?: Partial<PipecraftConfig>
 }
@@ -246,15 +246,22 @@ function buildTargetBranchExpression(branchFlow: string[]): string {
  */
 function buildAutoPromoteExpression(
   branchFlow: string[],
-  autoPromote?: Record<string, boolean>
+  autoPromote?: boolean | Record<string, boolean>
 ): string {
   if (!autoPromote || branchFlow.length === 1) return `'false'`
+
+  // autoPromote may be a global boolean (true = auto-promote every hop) or a per-target
+  // map ({ staging: true, main: false }). A bare `true` must enable every hop — indexing
+  // it as `true[targetBranch]` yields undefined, which previously made `autoPromote: true`
+  // silently behave as all-manual.
+  const allHops = autoPromote === true
+  const map = typeof autoPromote === 'object' ? autoPromote : {}
 
   const clauses: string[] = []
   for (let i = 0; i < branchFlow.length - 1; i += 1) {
     const sourceBranch = branchFlow[i]
     const targetBranch = branchFlow[i + 1]
-    const isEnabled = autoPromote[targetBranch] ? 'true' : 'false'
+    const isEnabled = allHops || map[targetBranch] ? 'true' : 'false'
     clauses.push(`(github.ref_name == '${sourceBranch}' && '${isEnabled}')`)
   }
 

--- a/tests/unit/auto-promote-boolean.test.ts
+++ b/tests/unit/auto-promote-boolean.test.ts
@@ -1,0 +1,41 @@
+/**
+ * autoPromote boolean form
+ *
+ * `autoPromote` may be a global boolean (true = auto-promote every hop) or a per-target
+ * map ({ staging: true, main: false }). The map form worked, but the boolean form was
+ * dead: buildAutoPromoteExpression did `autoPromote[targetBranch]`, and for the boolean
+ * `true`, `true['main']` is `undefined` -> 'false'. So `autoPromote: true` silently
+ * produced all-manual gates — the promote step received AUTO_PROMOTE="false" on every hop.
+ */
+import { describe, expect, it } from 'vitest'
+import { createTagPromoteReleaseOperations } from '../../src/templates/workflows/shared/operations-tag-promote.js'
+
+function autoPromoteExpr(autoPromote: unknown, branchFlow = ['develop', 'main']): string {
+  const ops = createTagPromoteReleaseOperations({
+    branchFlow,
+    // cast: the config type allows boolean | map; the test exercises both at runtime
+    autoPromote: autoPromote as never
+  })
+  const serialized = JSON.stringify(ops)
+  return serialized
+}
+
+describe('autoPromote boolean form', () => {
+  it('treats `autoPromote: true` as auto-promote on every hop', () => {
+    const s = autoPromoteExpr(true)
+    // The promotable source branch must map to 'true', not 'false'.
+    expect(s).toContain("github.ref_name == 'develop' && 'true'")
+    expect(s).not.toContain("github.ref_name == 'develop' && 'false'")
+  })
+
+  it('still honors a per-target map', () => {
+    const s = autoPromoteExpr({ alpha: true, main: false }, ['develop', 'alpha', 'main'])
+    expect(s).toContain("github.ref_name == 'develop' && 'true'") // -> alpha (true)
+    expect(s).toContain("github.ref_name == 'alpha' && 'false'") // -> main (false)
+  })
+
+  it('treats `autoPromote: false`/absent as all-manual', () => {
+    expect(autoPromoteExpr(false)).not.toContain("&& 'true'")
+    expect(autoPromoteExpr(undefined)).not.toContain("&& 'true'")
+  })
+})

--- a/tests/unit/create-release-idempotent.test.ts
+++ b/tests/unit/create-release-idempotent.test.ts
@@ -1,0 +1,34 @@
+/**
+ * create-release idempotency under set -e
+ *
+ * Composite action steps run with `bash -e -o pipefail`. The release step captured the
+ * gh output with `RELEASE_OUTPUT=$(gh release create ...)` and then inspected `$?` — but
+ * under `set -e` a failed command substitution in an assignment exits the script
+ * IMMEDIATELY, before `RELEASE_EXIT_CODE=$?` or the "already exists" idempotency branch
+ * could run. So a re-run for an existing version failed hard instead of no-opping.
+ *
+ * The fix wraps the gh call in `set +e` / `set -e` (the same guard the promote action uses
+ * for `gh pr create`) so the exit code is captured and the idempotency handler is reached.
+ */
+import { describe, expect, it } from 'vitest'
+import { releaseActionTemplate } from '../../src/templates/actions/create-release.yml.tpl.js'
+
+describe('create-release idempotency', () => {
+  const yaml = releaseActionTemplate({})
+
+  it('disables errexit around the gh release create call so its exit code is captured', () => {
+    const createIdx = yaml.indexOf('gh release create')
+    expect(createIdx).toBeGreaterThan(-1)
+    // `set +e` must appear before the create call, and `set -e` be restored after it.
+    const before = yaml.slice(Math.max(0, createIdx - 200), createIdx)
+    expect(before).toMatch(/set \+e/)
+    const after = yaml.slice(createIdx, createIdx + 300)
+    expect(after).toMatch(/RELEASE_EXIT_CODE=\$\?/)
+    expect(after).toMatch(/set -e/)
+  })
+
+  it('still treats an already-existing release as an idempotent success', () => {
+    expect(yaml).toMatch(/grep -qiE 'already exists'/)
+    expect(yaml).toContain('treating as success (idempotent)')
+  })
+})

--- a/tests/unit/promote-temp-branch.test.ts
+++ b/tests/unit/promote-temp-branch.test.ts
@@ -1,0 +1,38 @@
+/**
+ * promote-branch temp-branch handling
+ *
+ * The promote action stages a promotion on a temporary branch
+ * (pipecraft-promote/{source}-to-{target}-{version}) and opens a PR into the target.
+ *
+ * Bug this guards against: when a temp branch of the same name lingered from an earlier
+ * no-op promotion (manual-gate path never cleaned it up), a later promotion at the SAME
+ * version reused that stale branch AT ITS OLD COMMIT. `gh pr create` then saw "No commits
+ * between" and silently no-opped — so a real promotion produced no gate PR. The temp
+ * branch must ALWAYS reflect the current source tip, and a no-op must not leave an orphan.
+ */
+import { describe, expect, it } from 'vitest'
+import { promoteBranchActionTemplate } from '../../src/templates/actions/promote-branch.yml.tpl.js'
+
+describe('promote-branch temp-branch handling', () => {
+  const yaml = promoteBranchActionTemplate({})
+
+  it('force-syncs the temp branch to the current source tip', () => {
+    // Always point the temp branch at SOURCE's current commit (idempotent for both the
+    // fresh and the stale-existing case), then force-push so the remote matches.
+    expect(yaml).toMatch(/git branch -f "\$TEMP_BRANCH" "\$SOURCE"/)
+    expect(yaml).toMatch(/git push --force origin "\$TEMP_BRANCH"/)
+  })
+
+  it('does not blindly reuse an existing temp branch at its old commit', () => {
+    expect(yaml).not.toContain('already exists, using existing branch')
+  })
+
+  it('cleans up the orphan temp branch when there is nothing to promote', () => {
+    // On the "No commits between" no-op path the temp branch has no PR attached, so it
+    // must be deleted — otherwise a later same-version promotion collides with the orphan.
+    const noopIdx = yaml.indexOf('already up to date with')
+    expect(noopIdx).toBeGreaterThan(-1)
+    const noopBlock = yaml.slice(noopIdx, noopIdx + 400)
+    expect(noopBlock).toMatch(/git push origin --delete "\$TEMP_BRANCH"/)
+  })
+})


### PR DESCRIPTION
## Summary

Two real bugs found and fixed while building/proving a **mixed-promotion** example flavor (auto-promote `develop → staging`, manual gate `staging → main`). Both break the promotion cascade on perfectly ordinary re-runs.

### 1. `promote-branch`: stale temp-branch reuse → missing gate PR
The promote action staged each promotion on `pipecraft-promote/{source}-to-{target}-{version}`. When a branch of that name already existed (the manual-gate path never cleaned up its temp branch on a no-op promotion), it **reused the stale branch at its old commit** instead of re-syncing to the current source tip. `gh pr create` then reported *"No commits between"* and silently no-opped — so a genuine promotion produced **no gate PR**, even though the source had real commits to promote.

**Fix:** always `git branch -f` the temp branch to the source tip + force-push (idempotent on legitimate re-runs), and delete the orphan temp branch on the "nothing to promote" path.

**Reproduced live:** the gate PR to `main` was missing until the stale temp branch was deleted by hand; with the fix the cascade opens the PR on its own.

### 2. `create-release`: not idempotent under `set -e`
Composite steps run with `bash -e -o pipefail`. The release step did `RELEASE_OUTPUT=$(gh release create ...)` then checked `$?` — but under errexit a failed command substitution in an assignment exits **immediately**, before the exit code is captured or the existing `"already exists"` idempotency branch runs. A re-run for an already-released version failed hard (`Release.tag_name already exists`) instead of no-opping.

**Fix:** wrap the `gh release create` call in `set +e` / `set -e` (the same guard the promote action already uses for `gh pr create`).

## Tests
- `tests/unit/promote-temp-branch.test.ts` — asserts force-sync + orphan cleanup in the generated action.
- `tests/unit/create-release-idempotent.test.ts` — asserts the errexit guard + idempotent-success path.
- Full suite green (554 tests); snapshots unaffected (action content, not workflow shape).

## Proof
Mixed-promotion flavor (`the-craftlab/pipecraft-example-mixed`) now cascades end-to-end with **zero manual intervention**: `feat` on `develop` → auto-promoted to `staging` → gate PR `🚀 Release v0.1.0 to main` opened automatically → human-merge completes the manual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)