### PR TITLE
fix(setup): branch protection breaks merge-strategy auto-promote (GH006)

### DIFF
--- a/src/utils/github-setup.ts
+++ b/src/utils/github-setup.ts
@@ -1075,17 +1075,18 @@ export async function getBranchProtection(
 }
 
 /**
- * Update branch protection rules to enable auto-merge
+ * Build the branch-protection rules used for auto-promote target branches.
+ *
+ * `required_linear_history` MUST follow the merge strategy: with `mergeStrategy: merge`
+ * the auto-promote pushes a MERGE COMMIT to the target, and a branch that requires linear
+ * history rejects merge commits (GH006 "Protected branch update failed"), silently breaking
+ * the very auto-promote this protection is meant to support. Only fast-forward promotions
+ * produce linear history, so only they may require it.
  */
-export async function updateBranchProtection(
-  owner: string,
-  repo: string,
-  branch: string,
-  token: string
-): Promise<void> {
-  // Minimal branch protection to enable auto-merge
-  // GitHub requires at least ONE of the main protection types
-  const protection: BranchProtectionRules = {
+export function buildBranchProtectionRules(
+  mergeStrategy?: 'fast-forward' | 'merge'
+): BranchProtectionRules {
+  return {
     required_status_checks: {
       strict: false,
       contexts: [] // No specific checks required, but enables the feature
@@ -1095,9 +1096,24 @@ export async function updateBranchProtection(
     restrictions: null,
     allow_force_pushes: false,
     allow_deletions: false,
-    required_linear_history: true,
+    required_linear_history: mergeStrategy !== 'merge',
     required_conversation_resolution: false
   }
+}
+
+/**
+ * Update branch protection rules to enable auto-merge
+ */
+export async function updateBranchProtection(
+  owner: string,
+  repo: string,
+  branch: string,
+  token: string,
+  mergeStrategy?: 'fast-forward' | 'merge'
+): Promise<void> {
+  // Minimal branch protection to enable auto-merge.
+  // GitHub requires at least ONE of the main protection types.
+  const protection: BranchProtectionRules = buildBranchProtectionRules(mergeStrategy)
 
   const response = await fetch(
     `https://api.github.com/repos/${owner}/${repo}/branches/${branch}/protection`,
@@ -1226,7 +1242,13 @@ export async function configureBranchProtection(
         // Branch protection not configured
         if (autoApply) {
           console.log(`🔧 Configuring branch protection for ${branch}...`)
-          await updateBranchProtection(repoInfo.owner, repoInfo.repo, branch, token)
+          await updateBranchProtection(
+            repoInfo.owner,
+            repoInfo.repo,
+            branch,
+            token,
+            config.mergeStrategy
+          )
           console.log(`✅ Branch protection enabled for ${branch}`)
         } else {
           const response: any = await prompt({
@@ -1238,7 +1260,13 @@ export async function configureBranchProtection(
 
           if (response.enableProtection) {
             console.log(`🔧 Configuring branch protection for ${branch}...`)
-            await updateBranchProtection(repoInfo.owner, repoInfo.repo, branch, token)
+            await updateBranchProtection(
+              repoInfo.owner,
+              repoInfo.repo,
+              branch,
+              token,
+              config.mergeStrategy
+            )
             console.log(`✅ Branch protection enabled for ${branch}`)
           } else {
             console.log(`⚠️  Skipped ${branch}:`)

--- a/tests/unit/branch-protection-merge-strategy.test.ts
+++ b/tests/unit/branch-protection-merge-strategy.test.ts
@@ -1,0 +1,36 @@
+/**
+ * branch protection vs merge strategy
+ *
+ * setup-github protects auto-promote target branches. It used to hardcode
+ * `required_linear_history: true`, but with `mergeStrategy: merge` the auto-promote pushes
+ * a MERGE COMMIT to the target — and a branch that requires linear history rejects merge
+ * commits (GH006 "Protected branch update failed"), silently breaking the auto-promote the
+ * protection is meant to enable. Linear history may only be required for fast-forward
+ * promotions (which are linear by construction).
+ */
+import { describe, expect, it } from 'vitest'
+import { buildBranchProtectionRules } from '../../src/utils/github-setup.js'
+
+describe('branch protection vs merge strategy', () => {
+  it('does NOT require linear history for merge-strategy promotions', () => {
+    expect(buildBranchProtectionRules('merge').required_linear_history).toBe(false)
+  })
+
+  it('requires linear history for fast-forward promotions', () => {
+    expect(buildBranchProtectionRules('fast-forward').required_linear_history).toBe(true)
+  })
+
+  it('defaults to requiring linear history when strategy is unspecified', () => {
+    // Fast-forward is the default strategy, so the default protection matches it.
+    expect(buildBranchProtectionRules(undefined).required_linear_history).toBe(true)
+  })
+
+  it('keeps the rest of the protection minimal regardless of strategy', () => {
+    for (const s of ['merge', 'fast-forward'] as const) {
+      const p = buildBranchProtectionRules(s)
+      expect(p.required_pull_request_reviews).toBeNull()
+      expect(p.enforce_admins).toBe(false)
+      expect(p.required_status_checks).toEqual({ strict: false, contexts: [] })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`setup-github` protects auto-promote target branches but hardcoded `required_linear_history: true`. With `mergeStrategy: merge`, the auto-promote pushes a **merge commit** to the target — and a branch requiring linear history **rejects merge commits** (`GH006: Protected branch update failed`). The promotion push fails while `version`/`tag`/`release` still run, leaving the repo inconsistent: tags and a release are created but the branches never advance.

Fast-forward repos are unaffected (ff history is linear). This silently breaks `merge` + auto-promote + protection — the "full-featured" configuration.

## Fix
`required_linear_history` now follows the merge strategy (`true` only for fast-forward), threaded via `config.mergeStrategy` into `updateBranchProtection`. Extracted `buildBranchProtectionRules(mergeStrategy)` as a pure, unit-tested function.

## Proof
Reproduced live on the **basic** example flavor (`mergeStrategy: merge`, all auto-promote):
- **With** the old protection → promote push to protected `staging` fails `GH006`; feat never reaches `staging`/`main` despite tags + release appearing.
- **Without** protection → the identical merge cascade reaches `main` cleanly, zero failures.

This fix makes the protection compatible with merge promotions, so basic can run protected.

Tests: `tests/unit/branch-protection-merge-strategy.test.ts`. Full suite green (573).

🤖 Generated with [Claude Code](https://claude.com/claude-code)