### PR TITLE
fix(workflows): aux PR checks skip PipeCraft promotion PRs

### DIFF
--- a/src/templates/workflows/enforce-pr-target.yml.tpl.ts
+++ b/src/templates/workflows/enforce-pr-target.yml.tpl.ts
@@ -64,6 +64,9 @@ on:
 
 jobs:
   check-pr-target:
+    # Skip PipeCraft's own promotion PRs (pipecraft-promote/*). They legitimately target
+    # downstream/final branches as part of the flow; this guard is for human-authored PRs.
+    if: \${{ !startsWith(github.head_ref, 'pipecraft-promote/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check PR base branch

--- a/src/templates/workflows/pr-title-check.yml.tpl.ts
+++ b/src/templates/workflows/pr-title-check.yml.tpl.ts
@@ -108,6 +108,9 @@ permissions:
 jobs:
   main:
     name: Validate PR title
+    # Skip PipeCraft's own promotion PRs (pipecraft-promote/*): their titles are release
+    # messages ("🚀 Release X to Y"), not conventional commits, so the check shouldn't gate them.
+    if: \${{ !startsWith(github.head_ref, 'pipecraft-promote/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/tests/integration/aux-workflows-skip-promote.test.ts
+++ b/tests/integration/aux-workflows-skip-promote.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Auxiliary workflows skip PipeCraft promotion PRs
+ *
+ * enforce-pr-target and pr-title-check trigger on every pull_request. PipeCraft's own
+ * promotion PRs (head branch pipecraft-promote/*) legitimately target downstream/final
+ * branches and carry release-style titles — so without a guard, enforce-pr-target FAILS
+ * promote PRs to the final branch and pr-title-check FAILS their non-conventional titles,
+ * producing spurious red checks and noise on every promotion. Both jobs must be guarded to
+ * skip pipecraft-promote head branches.
+ */
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createMinimalConfig } from '../helpers/fixtures.js'
+import { createWorkspaceWithCleanup, inWorkspace } from '../helpers/workspace.js'
+
+const cliPath = join(__dirname, '..', '..', 'dist', 'cli', 'index.js')
+const GUARD = "!startsWith(github.head_ref, 'pipecraft-promote/')"
+
+describe('auxiliary workflows skip promotion PRs', () => {
+  let workspace: string
+  let cleanup: () => void
+
+  beforeEach(() => {
+    ;[workspace, cleanup] = createWorkspaceWithCleanup('aux-workflows')
+  })
+  afterEach(() => cleanup())
+
+  it.each(['enforce-pr-target.yml', 'pr-title-check.yml'])(
+    '%s skips pipecraft-promote head branches',
+    async file => {
+      await inWorkspace(workspace, () => {
+        execSync('git init', { cwd: workspace, stdio: 'pipe' })
+        execSync('git remote add origin https://github.com/test/test.git', {
+          cwd: workspace,
+          stdio: 'pipe'
+        })
+        // requireConventionalCommits enables pr-title-check.yml generation.
+        writeFileSync(
+          '.pipecraftrc',
+          JSON.stringify(createMinimalConfig({ requireConventionalCommits: true }), null, 2)
+        )
+        execSync(`node "${cliPath}" generate --skip-checks`, {
+          cwd: workspace,
+          stdio: 'pipe',
+          timeout: 15000,
+          env: { ...process.env, CI: 'true' }
+        })
+        const yaml = readFileSync(join(workspace, '.github/workflows', file), 'utf-8')
+        expect(yaml).toContain(GUARD)
+      })
+    }
+  )
+})


### PR DESCRIPTION
## Summary

`enforce-pr-target` and `pr-title-check` run on every `pull_request`. PipeCraft's own promotion PRs (head `pipecraft-promote/*`) legitimately target downstream/final branches and carry release-style titles, so without a guard they produce **spurious red checks** and noisy runs on every promotion:
- `enforce-pr-target` fails any promote PR whose base is the **final** branch (`base_ref == final → exit 1`),
- `pr-title-check` fails their non-conventional titles (`🚀 Release X to Y`).

This is the `action_required`/noisy-check behavior seen on promote PRs.

## Fix
Guard both jobs with `if: ${{ !startsWith(github.head_ref, 'pipecraft-promote/') }}` so they only gate human-authored PRs; promotion PRs skip them.

Test: `tests/integration/aux-workflows-skip-promote.test.ts`. Full suite green (587).

🤖 Generated with [Claude Code](https://claude.com/claude-code)