### PR TITLE
feat(ci): auto-sync example repos on release

### DIFF
--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -1,0 +1,62 @@
+name: Sync example repos
+
+# On each published release, regenerate the the-craftlab/pipecraft-example-* repos with the
+# new generator and open a PR per repo that drifted (the remote example also gets its
+# actionVersion bumped to the release tag). Repos already in sync are skipped.
+#
+# REQUIRED SECRET: EXAMPLES_TOKEN
+#   The default GITHUB_TOKEN only has access to THIS repo. Pushing branches and opening PRs
+#   on the separate example repos needs a token with write + pull-request access to them:
+#     - Fine-grained PAT scoped to the the-craftlab/pipecraft-example-* repos
+#       (Contents: Read and write, Pull requests: Read and write), or a classic PAT (repo), or
+#     - A GitHub App installation token with the same permissions.
+#   Add it as the repo/org Actions secret `EXAMPLES_TOKEN`. Without it this workflow no-ops
+#   with a clear message (it does not fail the release).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'pipecraft version tag to sync (defaults to the latest release)'
+        required: false
+        type: string
+
+jobs:
+  sync:
+    name: Regenerate example repos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI
+        run: pnpm build
+
+      - name: Sync example repos
+        env:
+          # See the header: EXAMPLES_TOKEN must have write + PR access to the example repos.
+          GH_TOKEN: ${{ secrets.EXAMPLES_TOKEN }}
+          VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::EXAMPLES_TOKEN is not set — skipping example sync."
+            echo "Add a token with write + PR access to the pipecraft-example-* repos as the"
+            echo "EXAMPLES_TOKEN secret to enable automatic example regeneration on release."
+            exit 0
+          fi
+          pnpm exec tsx scripts/sync-examples.ts --push ${VERSION:+--version "$VERSION"} all

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "e2e:reset": "tsx scripts/e2e/harness.ts reset",
     "e2e:prove": "tsx scripts/e2e/harness.ts prove",
     "e2e:run": "tsx scripts/e2e/harness.ts run",
+    "sync-examples": "tsx scripts/sync-examples.ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/sync-examples.ts
+++ b/scripts/sync-examples.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env tsx
+/**
+ * sync-examples — keep the live example repos in sync with the current generator.
+ *
+ *   tsx scripts/sync-examples.ts [--version <tag>] [--push] <flavor|all>
+ *
+ * For each flavor it clones the-craftlab/pipecraft-example-<flavor>, writes the canonical
+ * examples/<flavor> config (bumping `actionVersion` to <tag> for the remote flavor),
+ * regenerates the workflow/actions with the repo's freshly built CLI, and — if anything
+ * changed — opens a PR (`pipecraft-sync/<tag>`) into the repo's initial branch. Repos with
+ * no drift are skipped.
+ *
+ * Without `--push` it reports drift only (dry run). Designed to run from CI on each release
+ * (see .github/workflows/sync-examples.yml) but also runnable locally.
+ *
+ * Requires `gh` authenticated with write + PR access to the example repos, and `pnpm build`
+ * (the script invokes dist/cli/index.js).
+ */
+import { execSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { FLAVORS, configPathFor, readFlavorConfig, repoFor } from './e2e/flavors.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CLI = join(__dirname, '..', 'dist', 'cli', 'index.js')
+
+function sh(cmd: string, cwd?: string): string {
+  return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd }).trim()
+}
+function shq(cmd: string, cwd?: string): string {
+  try {
+    return sh(cmd, cwd)
+  } catch {
+    return ''
+  }
+}
+
+type Outcome = 'unchanged' | 'pr-opened' | 'pr-updated' | 'dry-run-drift'
+
+async function syncFlavor(flavor: string, version: string, push: boolean): Promise<Outcome> {
+  const repo = repoFor(flavor)
+  const config = readFlavorConfig(flavor)
+  if (config.actionSourceMode === 'remote' && version) config.actionVersion = version
+  const initial: string = config.branchFlow[0]
+  const branch = `pipecraft-sync/${version || 'latest'}`
+
+  const dir = mkdtempSync(join(tmpdir(), 'pc-sync-'))
+  try {
+    sh(`gh repo clone ${repo} ${dir} -- -q`)
+    sh('git config user.email "ci@thecraftlab.dev"', dir)
+    sh('git config user.name "pipecraft-ci"', dir)
+    sh(`git checkout ${initial}`, dir)
+
+    writeFileSync(join(dir, '.pipecraftrc.json'), `${JSON.stringify(config, null, 2)}\n`)
+    sh(`node "${CLI}" generate --skip-checks --force`, dir)
+
+    if (!sh('git status --porcelain', dir)) {
+      console.log(`   ${flavor}: in sync, nothing to do`)
+      return 'unchanged'
+    }
+    if (!push) {
+      console.log(`   ${flavor}: DRIFT (run with --push to open a PR)`)
+      console.log(sh('git --no-pager diff --stat', dir))
+      return 'dry-run-drift'
+    }
+
+    sh(`git checkout -B ${branch}`, dir)
+    sh('git add -A', dir)
+    sh(`git commit -qm "chore: sync generated workflow to pipecraft ${version || 'latest'}"`, dir)
+    sh(`git push -f origin ${branch}`, dir)
+
+    const existing = shq(
+      `gh pr list --repo ${repo} --head ${branch} --base ${initial} --state open --json number --jq '.[0].number'`
+    )
+    if (existing) {
+      console.log(`   ${flavor}: updated existing PR #${existing}`)
+      return 'pr-updated'
+    }
+    const url = sh(
+      `gh pr create --repo ${repo} --base ${initial} --head ${branch} ` +
+        `--title "chore: sync generated workflow to pipecraft ${version || 'latest'}" ` +
+        `--body "Automated by pipecraft sync-examples on release ${
+          version || 'latest'
+        }. Regenerates the workflow/actions from the current generator.${
+          config.actionSourceMode === 'remote' ? ` Pins \\\`actionVersion\\\` to ${version}.` : ''
+        }"`,
+      dir
+    )
+    console.log(`   ${flavor}: opened ${url}`)
+    return 'pr-opened'
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2)
+  const push = args.includes('--push')
+  const vIdx = args.indexOf('--version')
+  let version = vIdx >= 0 ? args[vIdx + 1] : ''
+  const positional = args.filter((a, i) => !a.startsWith('--') && !(vIdx >= 0 && i === vIdx + 1))
+  const target = positional[0] || 'all'
+
+  if (!existsSync(CLI)) {
+    console.error(`CLI not built at ${CLI} — run \`pnpm build\` first.`)
+    process.exit(2)
+  }
+  // Default to the latest published pipecraft release tag (matters for the remote flavor).
+  if (!version) {
+    version = shq(
+      "gh release list --repo the-craftlab/pipecraft --limit 1 --json tagName --jq '.[0].tagName'"
+    )
+  }
+  const flavors = target === 'all' ? [...FLAVORS] : target.split(',').map(f => f.trim())
+  for (const f of flavors) {
+    if (!existsSync(configPathFor(f))) {
+      console.error(`unknown flavor "${f}"`)
+      process.exit(2)
+    }
+  }
+
+  console.log(`🔄 sync-examples (version=${version || 'latest'}, push=${push})`)
+  const results: Record<string, Outcome> = {}
+  const failures: string[] = []
+  for (const flavor of flavors) {
+    try {
+      results[flavor] = await syncFlavor(flavor, version, push)
+    } catch (err) {
+      console.error(`❌ ${flavor}: ${(err as Error).message}`)
+      failures.push(flavor)
+    }
+  }
+
+  console.log(
+    `\nsummary: ${Object.entries(results)
+      .map(([f, o]) => `${f}=${o}`)
+      .join(', ')}`
+  )
+  if (failures.length) {
+    console.error(`❌ failed: ${failures.join(', ')}`)
+    process.exit(1)
+  }
+}
+
+void main()


### PR DESCRIPTION
## Summary

Closes the loop on keeping the live example repos current: on each **published release**, regenerate every `the-craftlab/pipecraft-example-*` repo with the new generator and open a PR per repo that drifted. The remote example also gets its `actionVersion` bumped to the release tag. Repos already in sync are skipped.

### Pieces
- **`scripts/sync-examples.ts`** — `pnpm sync-examples [--version <tag>] [--push] <flavor|all>`. Clones each example repo, writes the canonical `examples/<flavor>` config, regenerates with the CLI, and (with `--push`) opens/updates a `pipecraft-sync/<tag>` PR into the repo's initial branch. Without `--push` it's a dry run that reports drift. Reuses the flavor model from `scripts/e2e/flavors.ts`.
- **`.github/workflows/sync-examples.yml`** — runs on `release: published` (and `workflow_dispatch`).

### Required secret (the one manual step)
The workflow needs **`EXAMPLES_TOKEN`** — a token with **Contents: write** + **Pull requests: write** on the `pipecraft-example-*` repos (the default `GITHUB_TOKEN` only reaches this repo). Use a fine-grained PAT, classic PAT (`repo`), or a GitHub App token. Without it the job **no-ops with a warning** rather than failing the release.

### Why PRs, not direct pushes
Each sync lands as a reviewable PR per example repo, so drift is visible and you decide when to merge (or enable auto-merge on those repos).

### Validated live
- Dry run correctly reports drift (remote needs `actionVersion` v0.41.1 → v0.42.0; library in sync).
- `--push` opened a real sync PR on the remote example: the-craftlab/pipecraft-example-remote#6.

Full suite green (585).

🤖 Generated with [Claude Code](https://claude.com/claude-code)