### PR TITLE
fix(workflows): scope aux PR checks so promote PRs spawn no runs

### DIFF
--- a/src/templates/workflows/enforce-pr-target.yml.tpl.ts
+++ b/src/templates/workflows/enforce-pr-target.yml.tpl.ts
@@ -61,6 +61,12 @@ export const generate = (ctx: PinionContext) =>
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+    # Only PRs targeting the final branch matter here (the rule rejects human PRs to it).
+    # Scoping the trigger keeps PipeCraft's own promotion PRs to intermediate branches from
+    # spawning approval-gated runs at all; the job-level guard below covers promotion PRs
+    # that do target the final branch.
+    branches:
+      - ${finalBranch}
 
 jobs:
   check-pr-target:

--- a/src/templates/workflows/pr-title-check.yml.tpl.ts
+++ b/src/templates/workflows/pr-title-check.yml.tpl.ts
@@ -60,6 +60,9 @@ export const generate = (ctx: PinionContext) =>
     }
 
     return renderTemplate((ctx: any) => {
+      // Contributor PRs land on the initial branch; scope the trigger there so PipeCraft's
+      // own promotion PRs (which target downstream branches) never spawn this check.
+      const initialBranch = ctx.initialBranch || ctx.config?.initialBranch || 'develop'
       // Get all commit types from bumpRules config
       const bumpRules = ctx.config?.semver?.bumpRules || ctx.config?.versioning?.bumpRules || {}
       const allTypes = Object.keys(bumpRules)
@@ -100,6 +103,8 @@ on:
       - edited
       - synchronize
       - reopened
+    branches:
+      - ${initialBranch}
 
 permissions:
   pull-requests: write

--- a/tests/integration/aux-workflows-skip-promote.test.ts
+++ b/tests/integration/aux-workflows-skip-promote.test.ts
@@ -48,7 +48,12 @@ describe('auxiliary workflows skip promotion PRs', () => {
           env: { ...process.env, CI: 'true' }
         })
         const yaml = readFileSync(join(workspace, '.github/workflows', file), 'utf-8')
+        // Defense-in-depth guard: skip pipecraft-promote head branches.
         expect(yaml).toContain(GUARD)
+        // Trigger scoping: promote PRs target downstream branches, so neither check fires.
+        // pr-title-check is scoped to the initial branch; enforce-pr-target to the final.
+        const expectedBranch = file === 'pr-title-check.yml' ? 'develop' : 'main'
+        expect(yaml).toMatch(new RegExp(`branches:\\s*\\n\\s*-\\s*${expectedBranch}`))
       })
     }
   )


### PR DESCRIPTION
## Summary

Follow-up to #474. The job-level guard stopped `enforce-pr-target`/`pr-title-check` from **failing** on promotion PRs, but the runs were still **created** and sat as approval-gated `action_required` noise (the approval gate is evaluated before the job `if`).

Scope the triggers so promotion PRs (which target downstream branches) don't match the workflow at all:
- `pr-title-check` → `pull_request.branches: [<initialBranch>]` (contributor PRs only land on initial)
- `enforce-pr-target` → `pull_request.branches: [<finalBranch>]` (its only job is rejecting PRs to final)

Promote PRs to intermediate branches now spawn **neither** check. The job-level guards from #474 remain as defense for the one case that still triggers (a promotion PR whose base IS the final branch — enforce-pr-target fires there but skips instead of failing).

Test updated to assert both the guard and the trigger scoping. Full suite green (587); snapshots unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)